### PR TITLE
[Feat/#99] 궁금해요 TOP 2 작가 API GET

### DIFF
--- a/src/pages/groupFeed/GroupFeed.tsx
+++ b/src/pages/groupFeed/GroupFeed.tsx
@@ -59,7 +59,7 @@ const GroupFeed = () => {
             subText="매주 월요일마다 업데이트 됩니다"
           />
           <Spacing marginBottom="2" />
-          <CuriousProfile />
+          <CuriousProfile groupId={groupId} />
           <Spacing marginBottom="6.4" />
           <GroupCuriousTitle
             mainText="우리 모임에서 인기 있는 글이에요"

--- a/src/pages/groupFeed/GroupFeed.tsx
+++ b/src/pages/groupFeed/GroupFeed.tsx
@@ -52,13 +52,16 @@ const GroupFeed = () => {
           <GroupTodayWriteStyle isMember={isMember} groupId={groupId} />
           <Spacing marginBottom="6.4" />
           <GroupCuriousTitle
-            mainText="궁금해요 버튼이 많은 2명의 프로필"
-            subText="부연설명 텍스트"
+            mainText="우리 모임에서 궁금한 글쓴이에요"
+            subText="매주 월요일마다 업데이트 됩니다"
           />
           <Spacing marginBottom="2" />
           <CuriousProfile />
           <Spacing marginBottom="6.4" />
-          <GroupCuriousTitle mainText="궁금해요 버튼이 많은 2개의 글" subText="부연설명 텍스트" />
+          <GroupCuriousTitle
+            mainText="우리 모임에서 인기 있는 글이에요"
+            subText="매주 월요일마다 업데이트 됩니다"
+          />
           <Spacing marginBottom="2" />
           <CuriousArticle />
           <Spacing marginBottom="6.4" />

--- a/src/pages/groupFeed/GroupFeed.tsx
+++ b/src/pages/groupFeed/GroupFeed.tsx
@@ -8,6 +8,7 @@ import EachArticle from './carousel/EachArticle';
 import CuriousArticle from './components/CuriousArticle';
 import CuriousProfile from './components/CuriousProfile';
 import GroupCuriousTitle from './components/GroupCuriousTitle';
+import { LogOutHeader, GroupFeedHeader } from './components/GroupFeedHeader';
 import GroupSideHeader from './components/GroupSideHeader';
 import GroupTodayWriteStyle from './components/GroupTodayWriteStyle';
 import { useGroupFeedAuth, useGroupInfo } from './hooks/queries';
@@ -16,16 +17,18 @@ import GroupFloatingBtn from '../../assets/svgs/groupFloatingBtn.svg';
 import GroupFloatingBtnHover from '../../assets/svgs/groupFloatingBtnHover.svg';
 import GroupThumbnailImg from '../../assets/svgs/groupThumnailImg.svg';
 import Footer from '../../components/commons/Footer';
-import { GroupFeedHeader, LogOutHeader } from '../../components/commons/Header';
 import Spacing from '../../components/commons/Spacing';
 
 const GroupFeed = () => {
   const { groupId } = useParams();
-  const { isMember, isLoading, isError, error } = useGroupFeedAuth(groupId || '');
+  const accessToken = localStorage.getItem('accessToken');
+  const { isMember, isLoading, isError, error } = useGroupFeedAuth(
+    groupId || '',
+    accessToken || '',
+  );
   const { groupInfoData } = useGroupInfo(groupId || '');
 
   const [activeCategoryId, setActiveCategoryId] = useState<number>(1);
-  const accessToken = localStorage.getItem('accessToken');
 
   const navigate = useNavigate();
 

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -16,6 +16,7 @@ export const fetchGroupFeedAuth = async (groupId: string) => {
         Authorization: `Bearer ${accessToken}`,
       },
     });
+    console.log(response.data, 'fetchgRoup');
     return response.data; //"isMember" : boolean
   } catch (error) {
     console.error('에러:', error);
@@ -64,22 +65,16 @@ export const fetchTodayTopic = async (groupId: string) => {
 
 interface CuriousWriterPropTypes {
   data: {
-    popularWriters: [
-      {
-        writerName: string;
-        information: string;
-      },
-      {
-        writerName: string;
-        information: string;
-      },
-    ];
+    popularWriters: {
+      writerName: string;
+      information: string;
+    }[];
   };
   status: number;
   message: string;
 }
 
-export const fetchCuriousWriter = async (groupId: string) => {
+export const fetchCuriousWriters = async (groupId: string) => {
   try {
     const response = await client.get<CuriousWriterPropTypes>(
       `/api/moim/${groupId}/mostCuriousWriters`,

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -45,9 +45,17 @@ export const fetchGroupInfo = async (groupId: string) => {
   }
 };
 
+interface TodayTopicPropTypes {
+  data: {
+    content: string;
+  };
+  status: number;
+  message: string;
+}
+
 export const fetchTodayTopic = async (groupId: string) => {
   try {
-    const response = await client.get(`/api/moim/${groupId}/topic`);
+    const response = await client.get<TodayTopicPropTypes>(`/api/moim/${groupId}/topic`);
     return response.data;
   } catch (error) {
     console.error('에러:', error);

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -61,3 +61,32 @@ export const fetchTodayTopic = async (groupId: string) => {
     console.error('에러:', error);
   }
 };
+
+interface CuriousWriterPropTypes {
+  data: {
+    popularWriters: [
+      {
+        writerName: string;
+        information: string;
+      },
+      {
+        writerName: string;
+        information: string;
+      },
+    ];
+  };
+  status: number;
+  message: string;
+}
+
+export const fetchCuriousWriter = async (groupId: string) => {
+  try {
+    const response = await client.get<CuriousWriterPropTypes>(
+      `/api/moim/${groupId}/mostCuriousWriters`,
+    );
+    console.log(response.data, '데이터');
+    return response.data;
+  } catch (error) {
+    console.error('에러:', error);
+  }
+};

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -45,7 +45,7 @@ export const fetchGroupInfo = async (groupId: string) => {
   }
 };
 
-export const fetchTodayWritingStyle = async (groupId: string) => {
+export const fetchTodayTopic = async (groupId: string) => {
   try {
     const response = await client.get(`/api/moim/${groupId}/topic`);
     return response.data;

--- a/src/pages/groupFeed/components/CuriousProfile.tsx
+++ b/src/pages/groupFeed/components/CuriousProfile.tsx
@@ -1,18 +1,26 @@
 import styled from '@emotion/styled';
 
+import { CURIOUS_PROFILE } from '../constants/CURIOUS_PROFILE';
+import { useCuriousWriters } from '../hooks/queries';
+
 import { GroupBestProfileIc, GroupNoDataImgIc } from '../../../assets/svgs';
 import Spacing from '../../../components/commons/Spacing';
-import { CURIOUS_PROFILE } from '../constants/CURIOUS_PROFILE';
 
 interface ProfilePropTypes {
   writerName: string;
   information: string;
 }
 
-const CuriousProfile = () => {
+interface CuriousProfilePropTypes {
+  groupId: string | undefined;
+}
+
+const CuriousProfile = (props: CuriousProfilePropTypes) => {
+  const { groupId } = props;
+  const { curiousWriterData } = useCuriousWriters(groupId || '');
   return (
     <CuriousProfileWrapper>
-      {CURIOUS_PROFILE.popularWriters.length == 0 ? (
+      {curiousWriterData?.length == 0 ? (
         <NoCuriousProfileeWrapper>
           <Spacing marginBottom="4" />
           <GroupNoDataImgIc />
@@ -21,7 +29,7 @@ const CuriousProfile = () => {
           <Spacing marginBottom="4" />
         </NoCuriousProfileeWrapper>
       ) : (
-        CURIOUS_PROFILE.popularWriters.map((writer: ProfilePropTypes, index: number) => (
+        curiousWriterData?.map((writer: ProfilePropTypes, index: number) => (
           <CuriousProfileLayout key={index}>
             <GroupBestProfileIc />
             <ProfileWrapper>

--- a/src/pages/groupFeed/components/CuriousProfile.tsx
+++ b/src/pages/groupFeed/components/CuriousProfile.tsx
@@ -25,7 +25,7 @@ const CuriousProfile = (props: CuriousProfilePropTypes) => {
           <Spacing marginBottom="4" />
           <GroupNoDataImgIc />
           <Spacing marginBottom="1.6" />
-          아직은 굼금해요를 많이 받은 작가가 없어요
+          아직 궁금해요를 받은 필명의 글쓴이가 없어요
           <Spacing marginBottom="4" />
         </NoCuriousProfileeWrapper>
       ) : (

--- a/src/pages/groupFeed/components/CuriousProfile.tsx
+++ b/src/pages/groupFeed/components/CuriousProfile.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import { CURIOUS_PROFILE } from '../constants/CURIOUS_PROFILE';
 import { useCuriousWriters } from '../hooks/queries';
 
 import { GroupBestProfileIc, GroupNoDataImgIc } from '../../../assets/svgs';

--- a/src/pages/groupFeed/components/GroupFeedHeader.tsx
+++ b/src/pages/groupFeed/components/GroupFeedHeader.tsx
@@ -12,18 +12,18 @@ interface OnClickProps {
   onClick: () => void;
 }
 
-interface onClickEditProps {
-  onClickEditSave: () => void;
-}
+// interface onClickEditProps {
+//   onClickEditSave: () => void;
+// }
 
-interface OnClickTwoProps {
-  onClickTempSave: () => void;
-  onClickSubmit: () => void;
-}
+// interface OnClickTwoProps {
+//   onClickTempSave: () => void;
+//   onClickSubmit: () => void;
+// }
 
-interface OnClickTempExistProps {
-  onClickSubmit: () => void;
-}
+// interface OnClickTempExistProps {
+//   onClickSubmit: () => void;
+// }
 
 // 모임 피드 헤더
 export const GroupFeedHeader = () => {

--- a/src/pages/groupFeed/components/GroupFeedHeader.tsx
+++ b/src/pages/groupFeed/components/GroupFeedHeader.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+
+import MakeGroupBtn from './MakeGroupBtn';
+import MyGroupBtn from './MyGroupBtn';
+
+import { HeaderLogoIc } from '../../../assets/svgs';
+import Button from '../../../components/commons/Button';
+import LogInOutBtn from '../../../components/commons/LogInOutBtn';
+import logout from '../../../utils/logout';
+
+interface OnClickProps {
+  onClick: () => void;
+}
+
+interface onClickEditProps {
+  onClickEditSave: () => void;
+}
+
+interface OnClickTwoProps {
+  onClickTempSave: () => void;
+  onClickSubmit: () => void;
+}
+
+interface OnClickTempExistProps {
+  onClickSubmit: () => void;
+}
+
+// 모임 피드 헤더
+export const GroupFeedHeader = () => {
+  const logout2 = () => {
+    localStorage.removeItem('accessToken');
+    console.log('removed');
+  };
+  return (
+    <HeaderWrapper>
+      <HeaderLogoIc />
+      <HeaderBtnLayout>
+        <MyGroupBtn />
+        <CommonBtnLayout>
+          <MakeGroupBtn />
+          <LogInOutBtn onClick={logout2}>로그아웃</LogInOutBtn>
+        </CommonBtnLayout>
+      </HeaderBtnLayout>
+    </HeaderWrapper>
+  );
+};
+
+//아직 로그인을 하지 않았을 때 헤더
+export const LogOutHeader = ({ onClick }: OnClickProps) => {
+  return (
+    <HeaderWrapper>
+      <HeaderLogoIc />
+      <LogInOutBtn onClick={onClick}>로그인</LogInOutBtn>
+    </HeaderWrapper>
+  );
+};
+const HeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 6.4rem;
+  padding-right: 6rem;
+  padding-left: 6rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray30};
+`;
+
+const HeaderBtnLayout = styled.div`
+  display: flex;
+  align-items: center;
+  height: 6.4rem;
+`;
+
+const CommonBtnLayout = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+  height: 6.4rem;
+`;

--- a/src/pages/groupFeed/components/GroupFeedHeader.tsx
+++ b/src/pages/groupFeed/components/GroupFeedHeader.tsx
@@ -4,7 +4,6 @@ import MakeGroupBtn from './MakeGroupBtn';
 import MyGroupBtn from './MyGroupBtn';
 
 import { HeaderLogoIc } from '../../../assets/svgs';
-import Button from '../../../components/commons/Button';
 import LogInOutBtn from '../../../components/commons/LogInOutBtn';
 import logout from '../../../utils/logout';
 
@@ -27,10 +26,6 @@ interface OnClickProps {
 
 // 모임 피드 헤더
 export const GroupFeedHeader = () => {
-  const logout2 = () => {
-    localStorage.removeItem('accessToken');
-    console.log('removed');
-  };
   return (
     <HeaderWrapper>
       <HeaderLogoIc />
@@ -38,7 +33,7 @@ export const GroupFeedHeader = () => {
         <MyGroupBtn />
         <CommonBtnLayout>
           <MakeGroupBtn />
-          <LogInOutBtn onClick={logout2}>로그아웃</LogInOutBtn>
+          <LogInOutBtn onClick={logout}>로그아웃</LogInOutBtn>
         </CommonBtnLayout>
       </HeaderBtnLayout>
     </HeaderWrapper>

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -51,14 +51,7 @@ export const useGroupInfo = (groupId: string): GroupInfoQueryResult => {
   return { groupInfoData, isLoading, isError, error };
 };
 
-interface WritingStyleQueryResult {
-  content: boolean;
-  isLoading: boolean;
-  isError: boolean;
-  error: Error | null;
-}
-
-export const useTodayWritingStyle = (groupId: string): WritingStyleQueryResult => {
+export const useTodayWritingStyle = (groupId: string) => {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [QUERY_KEY_GROUPFEED.getTodayWritingStyle, groupId],
     queryFn: () => fetchTodayTopic(groupId),

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -78,7 +78,6 @@ export const useCuriousWriters = (groupId: string) => {
   });
 
   const curiousWriterData = data && data.data.popularWriters;
-  console.log(curiousWriterData, 'datis');
-  console.log(curiousWriterData?.length, '길이');
+
   return { curiousWriterData, isLoading, isError, error };
 };

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -1,6 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchGroupFeedAuth, fetchTodayTopic, fetchGroupInfo } from '../apis/fetchGroupFeed';
+import {
+  fetchGroupFeedAuth,
+  fetchTodayTopic,
+  fetchGroupInfo,
+  fetchCuriousWriters,
+} from '../apis/fetchGroupFeed';
 
 export const QUERY_KEY_GROUPFEED = {
   getGroupFeedAuth: 'getGroupFeedAuth',
@@ -14,10 +19,14 @@ interface GroupFeedAuthQueryResult {
   error: Error | null;
 }
 
-export const useGroupFeedAuth = (groupId: string): GroupFeedAuthQueryResult => {
+export const useGroupFeedAuth = (
+  groupId: string,
+  accessToken: string | null,
+): GroupFeedAuthQueryResult => {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [QUERY_KEY_GROUPFEED.getGroupFeedAuth, groupId],
     queryFn: () => fetchGroupFeedAuth(groupId),
+    enabled: !!accessToken,
   });
 
   const isMember = data && data.data.isMember;
@@ -55,6 +64,16 @@ export const useTodayWritingStyle = (groupId: string) => {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [QUERY_KEY_GROUPFEED.getTodayWritingStyle, groupId],
     queryFn: () => fetchTodayTopic(groupId),
+  });
+
+  const content = data && data.data.content;
+  return { content, isLoading, isError, error };
+};
+
+export const useCuriousWriters = (groupId: string) => {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: [QUERY_KEY_GROUPFEED.getTodayWritingStyle, groupId],
+    queryFn: () => fetchCuriousWriters(groupId),
   });
 
   const content = data && data.data.content;

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -10,6 +10,7 @@ import {
 export const QUERY_KEY_GROUPFEED = {
   getGroupFeedAuth: 'getGroupFeedAuth',
   getTodayWritingStyle: 'getTodayWritingStyle',
+  getCuriousWriters: 'getCuriousWriters',
 };
 
 interface GroupFeedAuthQueryResult {
@@ -72,10 +73,10 @@ export const useTodayWritingStyle = (groupId: string) => {
 
 export const useCuriousWriters = (groupId: string) => {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: [QUERY_KEY_GROUPFEED.getTodayWritingStyle, groupId],
+    queryKey: [QUERY_KEY_GROUPFEED.getCuriousWriters, groupId],
     queryFn: () => fetchCuriousWriters(groupId),
   });
 
-  const content = data && data.data.content;
+  const content = data && data.data;
   return { content, isLoading, isError, error };
 };

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -77,6 +77,8 @@ export const useCuriousWriters = (groupId: string) => {
     queryFn: () => fetchCuriousWriters(groupId),
   });
 
-  const content = data && data.data;
-  return { content, isLoading, isError, error };
+  const curiousWriterData = data && data.data.popularWriters;
+  console.log(curiousWriterData, 'datis');
+  console.log(curiousWriterData?.length, '길이');
+  return { curiousWriterData, isLoading, isError, error };
 };

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchGroupFeedAuth, fetchTodayWritingStyle, fetchGroupInfo } from '../apis/fetchGroupFeed';
+import { fetchGroupFeedAuth, fetchTodayTopic, fetchGroupInfo } from '../apis/fetchGroupFeed';
 
 export const QUERY_KEY_GROUPFEED = {
   getGroupFeedAuth: 'getGroupFeedAuth',
@@ -61,7 +61,7 @@ interface WritingStyleQueryResult {
 export const useTodayWritingStyle = (groupId: string): WritingStyleQueryResult => {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [QUERY_KEY_GROUPFEED.getTodayWritingStyle, groupId],
-    queryFn: () => fetchTodayWritingStyle(groupId),
+    queryFn: () => fetchTodayTopic(groupId),
   });
 
   const content = data && data.data.content;


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #99 


### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 궁금해요 TOP 2 작가 API GET
- [x] 모임에 대한 권한 확인 API GET 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 다은이 라우팅할 때 모임에 대한 권한 확인 API GET에서 에러가 생겼었는데 제 문제였더라고요?ㅎ...
문제 : 500에러 뜸. 
해결 : accessToken이 없을 때에는 요청을 보내면 안됨. 쿼리훅으로 accessToken을 prop로 보내고, 그걸 받아서 enabled 설정을 해줬습니다

```typescript
  const { data, isLoading, isError, error } = useQuery({
    queryKey: [QUERY_KEY_GROUPFEED.getGroupFeedAuth, groupId],
    queryFn: () => fetchGroupFeedAuth(groupId),
    enabled: !!accessToken,
  });
```

이렇게 설정하면 useQuery 훅이 accessToken이 존재할 때만 실행되도록 설정됨!!

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

case1) 궁금한 작가가 없을 때
<img width="750" alt="Screenshot 2024-01-15 at 4 08 40 PM" src="https://github.com/Mile-Writings/Mile-Client/assets/93575538/32fe8933-73ec-4543-98da-b674f189266e">

case2) 궁금한 작가가 1명 있을 때
<img width="765" alt="Screenshot 2024-01-15 at 4 09 03 PM" src="https://github.com/Mile-Writings/Mile-Client/assets/93575538/3b83d41c-8c91-443c-8267-f6fa77bad820">

case3) 궁금한 작가가 2명 있을 때
<img width="785" alt="Screenshot 2024-01-15 at 4 09 19 PM" src="https://github.com/Mile-Writings/Mile-Client/assets/93575538/7a3d274e-0b53-4ecd-9f4b-213b6dbb71bd">


