### PR TITLE
[Refactor/#239] 에디터 툴바 글자 배경 색상 변경 뷰 커스텀

### DIFF
--- a/src/assets/svgs/index.tsx
+++ b/src/assets/svgs/index.tsx
@@ -72,6 +72,7 @@ export { default as EditorCatIc } from './editorCatSvg.svg?react';
 export { default as faviconMileIc } from './faviconMile.svg?react';
 
 // 에디터 툴바 아이콘
+// 글자색
 export { default as EditorTextColorBlackIcn } from './editorTextcolorIcnBlack.svg?react';
 export { default as EditorTextColorBlueIcn } from './editorTextcolorIcnBlue.svg?react';
 export { default as EditorTextColorGrayIcn } from './editorTextcolorIcnGray.svg?react';
@@ -81,3 +82,13 @@ export { default as EditorTextColorPinkIcn } from './editorTextcolorIcnPink.svg?
 export { default as EditorTextColorRedIcn } from './editorTextcolorIcnRed.svg?react';
 export { default as EditorTextColorVioletIcn } from './editorTextcolorIcnViolet.svg?react';
 export { default as EditorTextColorYellowIcn } from './editorTextcolorIcnYellow.svg?react';
+// 글자 배경색
+export { default as EditorTextBgColorBlueIcn } from './editorTextbasecolorIcnBlue.svg?react';
+export { default as EditorTextBgColorGrayIcn } from './editorTextbasecolorIcnGray.svg?react';
+export { default as EditorTextBgColorGreenIcn } from './editorTextbasecolorIcnGreen.svg?react';
+export { default as EditorTextBgColorOrangeIcn } from './editorTextbasecolorIcnOrange.svg?react';
+export { default as EditorTextBgColorPinkIcn } from './editorTextbasecolorIcnPink.svg?react';
+export { default as EditorTextBgColorRedIcn } from './editorTextbasecolorIcnRed.svg?react';
+export { default as EditorTextBgColorVioletIcn } from './editorTextbasecolorIcnViolet.svg?react';
+export { default as EditorTextBgColorWhiteIcn } from './editorTextbasecolorIcnWhite.svg?react';
+export { default as EditorTextBgColorYellowIcn } from './editorTextbasecolorIcnBlue.svg?react';

--- a/src/assets/svgs/index.tsx
+++ b/src/assets/svgs/index.tsx
@@ -91,4 +91,4 @@ export { default as EditorTextBgColorPinkIcn } from './editorTextbasecolorIcnPin
 export { default as EditorTextBgColorRedIcn } from './editorTextbasecolorIcnRed.svg?react';
 export { default as EditorTextBgColorVioletIcn } from './editorTextbasecolorIcnViolet.svg?react';
 export { default as EditorTextBgColorWhiteIcn } from './editorTextbasecolorIcnWhite.svg?react';
-export { default as EditorTextBgColorYellowIcn } from './editorTextbasecolorIcnBlue.svg?react';
+export { default as EditorTextBgColorYellowIcn } from './editorTextbasecolorIcnYellow.svg?react';

--- a/src/pages/postPage/components/TipTap.tsx
+++ b/src/pages/postPage/components/TipTap.tsx
@@ -448,99 +448,100 @@ const TipTap = (props: EditorPropTypes) => {
             {isFontSizeOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
           </TextColorToggle>
           <TextColorList $isFontColorOpen={isFontColorOpen}>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorWhiteIcn />
-              <TextColorText>white</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightWhite}>
+              <EditorTextBgColorWhiteIcn
+                className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
+              >
+                white
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorGrayIcn />
-              <TextColorText>gray</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightGray}>
+              <EditorTextBgColorGrayIcn
+                className={editor.isActive('highlight', { color: '#EAEAEA' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#EAEAEA' }) ? 'is-active' : ''}
+              >
+                gray
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorRedIcn />
-              <TextColorText>red</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightRed}>
+              <EditorTextBgColorRedIcn
+                className={editor.isActive('highlight', { color: '#F6E2E2' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#F6E2E2' }) ? 'is-active' : ''}
+              >
+                red
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorOrangeIcn />
-              <TextColorText>orange</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightOrange}>
+              <EditorTextBgColorOrangeIcn
+                className={editor.isActive('highlight', { color: '#F6E7E2' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#F6E7E2' }) ? 'is-active' : ''}
+              >
+                orange
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorYellowIcn />
-              <TextColorText>yellow</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightYellow}>
+              <EditorTextBgColorYellowIcn
+                className={editor.isActive('highlight', { color: '#F6F4E2' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#F6F4E2' }) ? 'is-active' : ''}
+              >
+                yellow
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorGreenIcn />
-              <TextColorText>green</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightGreen}>
+              <EditorTextBgColorGreenIcn
+                className={editor.isActive('highlight', { color: '#F1F6E2' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#F1F6E2' }) ? 'is-active' : ''}
+              >
+                green
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorBlueIcn />
-              <TextColorText>blue</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightBlue}>
+              <EditorTextBgColorBlueIcn
+                className={editor.isActive('highlight', { color: '#E2EAF6' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#E2EAF6' }) ? 'is-active' : ''}
+              >
+                blue
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorVioletIcn />
-              <TextColorText>violet</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightViolet}>
+              <EditorTextBgColorVioletIcn
+                className={editor.isActive('highlight', { color: '#E9E3F8' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#E9E3F8' }) ? 'is-active' : ''}
+              >
+                violet
+              </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper>
-              <EditorTextBgColorPinkIcn />
-              <TextColorText>pink</TextColorText>
+            <TextColorOptionWrapper onClick={toggleHighLightPink}>
+              <EditorTextBgColorPinkIcn
+                className={editor.isActive('highlight', { color: '#F6E2F3' }) ? 'is-active' : ''}
+              />
+              <TextColorText
+                className={editor.isActive('highlight', { color: '#F6E2F3' }) ? 'is-active' : ''}
+              >
+                pink
+              </TextColorText>
             </TextColorOptionWrapper>
           </TextColorList>
         </ToolbarDropDownWrapper>
-        <button
-          className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
-          onClick={toggleHighLightWhite}
-        >
-          white
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#EAEAEA' }) ? 'is-active' : ''}
-          onClick={toggleHighLightGray}
-        >
-          gray
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#F6E2E2' }) ? 'is-active' : ''}
-          onClick={toggleHighLightRed}
-        >
-          red
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#F6E7E2' }) ? 'is-active' : ''}
-          onClick={toggleHighLightOrange}
-        >
-          orange
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#F6F4E2' }) ? 'is-active' : ''}
-          onClick={toggleHighLightYellow}
-        >
-          yellow
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#F1F6E2' }) ? 'is-active' : ''}
-          onClick={toggleHighLightGreen}
-        >
-          green
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#E2EAF6' }) ? 'is-active' : ''}
-          onClick={toggleHighLightBlue}
-        >
-          blue
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#E9E3F8' }) ? 'is-active' : ''}
-          onClick={toggleHighLightViolet}
-        >
-          violet
-        </button>
-        <button
-          className={editor.isActive('highlight', { color: '#F6E2F3' }) ? 'is-active' : ''}
-          onClick={toggleHighLightPink}
-        >
-          pink
-        </button>
 
+        {/* bold */}
         <button
           className={classNames('menu-button', {
             'is-active': editor.isActive('bold'),

--- a/src/pages/postPage/components/TipTap.tsx
+++ b/src/pages/postPage/components/TipTap.tsx
@@ -444,7 +444,27 @@ const TipTap = (props: EditorPropTypes) => {
         {/* 글자 배경색 */}
         <ToolbarDropDownWrapper>
           <TextColorToggle>
-            <EditorTextBgColorWhiteIcn />
+            {editor.isActive('highlight', { color: '#FFFFFF' }) ? (
+              <EditorTextBgColorWhiteIcn />
+            ) : editor.isActive('highlight', { color: '#EAEAEA' }) ? (
+              <EditorTextBgColorGrayIcn />
+            ) : editor.isActive('highlight', { color: '#F6E2E2' }) ? (
+              <EditorTextBgColorRedIcn />
+            ) : editor.isActive('highlight', { color: '#F6E7E2' }) ? (
+              <EditorTextBgColorOrangeIcn />
+            ) : editor.isActive('highlight', { color: '#F6F4E2' }) ? (
+              <EditorTextBgColorYellowIcn />
+            ) : editor.isActive('highlight', { color: '#F1F6E2' }) ? (
+              <EditorTextBgColorGreenIcn />
+            ) : editor.isActive('highlight', { color: '#E2EAF6' }) ? (
+              <EditorTextBgColorBlueIcn />
+            ) : editor.isActive('highlight', { color: '#E9E3F8' }) ? (
+              <EditorTextBgColorVioletIcn />
+            ) : editor.isActive('highlight', { color: '#F6E2F3' }) ? (
+              <EditorTextBgColorPinkIcn />
+            ) : (
+              <EditorTextBgColorWhiteIcn />
+            )}
             {isFontSizeOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
           </TextColorToggle>
           <TextColorList $isFontColorOpen={isFontColorOpen}>

--- a/src/pages/postPage/components/TipTap.tsx
+++ b/src/pages/postPage/components/TipTap.tsx
@@ -194,42 +194,13 @@ const TipTap = (props: EditorPropTypes) => {
   }, [editor]);
 
   // 글자 배경색 함수
-  const toggleHighLightWhite = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#FFFFFF' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightGray = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#EAEAEA' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightRed = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#F6E2E2' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightOrange = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#F6E7E2' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightYellow = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#F6F4E2' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightGreen = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#F1F6E2' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightBlue = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#E2EAF6' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightViolet = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#E9E3F8' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
-  const toggleHighLightPink = useCallback(() => {
-    editor.chain().focus().toggleHighlight({ color: '#F6E2F3' }).run();
-    setIsFontBgColorOpen(false);
-  }, [editor]);
+  const toggleTextBgColor = useCallback(
+    (color: string) => {
+      editor.chain().focus().toggleHighlight({ color: color }).run();
+      setIsFontBgColorOpen(false);
+    },
+    [editor],
+  );
 
   // bold 함수
   const toggleBold = useCallback(() => {
@@ -484,7 +455,7 @@ const TipTap = (props: EditorPropTypes) => {
             {isFontBgColorOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
           </TextColorToggle>
           <TextColorBgList $isFontBgColorOpen={isFontBgColorOpen}>
-            <TextColorOptionWrapper onClick={toggleHighLightWhite}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#FFFFFF')}>
               <EditorTextBgColorWhiteIcn
                 className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
               />
@@ -494,7 +465,7 @@ const TipTap = (props: EditorPropTypes) => {
                 white
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightGray}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#EAEAEA')}>
               <EditorTextBgColorGrayIcn
                 className={editor.isActive('highlight', { color: '#EAEAEA' }) ? 'is-active' : ''}
               />
@@ -504,7 +475,7 @@ const TipTap = (props: EditorPropTypes) => {
                 gray
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightRed}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#F6E2E2')}>
               <EditorTextBgColorRedIcn
                 className={editor.isActive('highlight', { color: '#F6E2E2' }) ? 'is-active' : ''}
               />
@@ -514,7 +485,7 @@ const TipTap = (props: EditorPropTypes) => {
                 red
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightOrange}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#F6E7E2')}>
               <EditorTextBgColorOrangeIcn
                 className={editor.isActive('highlight', { color: '#F6E7E2' }) ? 'is-active' : ''}
               />
@@ -524,7 +495,7 @@ const TipTap = (props: EditorPropTypes) => {
                 orange
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightYellow}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#F6F4E2')}>
               <EditorTextBgColorYellowIcn
                 className={editor.isActive('highlight', { color: '#F6F4E2' }) ? 'is-active' : ''}
               />
@@ -534,7 +505,7 @@ const TipTap = (props: EditorPropTypes) => {
                 yellow
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightGreen}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#F1F6E2')}>
               <EditorTextBgColorGreenIcn
                 className={editor.isActive('highlight', { color: '#F1F6E2' }) ? 'is-active' : ''}
               />
@@ -544,7 +515,7 @@ const TipTap = (props: EditorPropTypes) => {
                 green
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightBlue}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#E2EAF6')}>
               <EditorTextBgColorBlueIcn
                 className={editor.isActive('highlight', { color: '#E2EAF6' }) ? 'is-active' : ''}
               />
@@ -554,7 +525,7 @@ const TipTap = (props: EditorPropTypes) => {
                 blue
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightViolet}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#E9E3F8')}>
               <EditorTextBgColorVioletIcn
                 className={editor.isActive('highlight', { color: '#E9E3F8' }) ? 'is-active' : ''}
               />
@@ -564,7 +535,7 @@ const TipTap = (props: EditorPropTypes) => {
                 violet
               </TextColorText>
             </TextColorOptionWrapper>
-            <TextColorOptionWrapper onClick={toggleHighLightPink}>
+            <TextColorOptionWrapper onClick={() => toggleTextBgColor('#F6E2F3')}>
               <EditorTextBgColorPinkIcn
                 className={editor.isActive('highlight', { color: '#F6E2F3' }) ? 'is-active' : ''}
               />

--- a/src/pages/postPage/components/TipTap.tsx
+++ b/src/pages/postPage/components/TipTap.tsx
@@ -41,6 +41,15 @@ import {
   EditorTextColorRedIcn,
   EditorTextColorVioletIcn,
   EditorTextColorYellowIcn,
+  EditorTextBgColorBlueIcn,
+  EditorTextBgColorGrayIcn,
+  EditorTextBgColorGreenIcn,
+  EditorTextBgColorOrangeIcn,
+  EditorTextBgColorPinkIcn,
+  EditorTextBgColorRedIcn,
+  EditorTextBgColorVioletIcn,
+  EditorTextBgColorWhiteIcn,
+  EditorTextBgColorYellowIcn,
 } from '../../../assets/svgs';
 
 interface EditorPropTypes {
@@ -433,6 +442,50 @@ const TipTap = (props: EditorPropTypes) => {
         </ToolbarDropDownWrapper>
 
         {/* 글자 배경색 */}
+        <ToolbarDropDownWrapper>
+          <TextColorToggle>
+            <EditorTextBgColorWhiteIcn />
+            {isFontSizeOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
+          </TextColorToggle>
+          <TextColorList $isFontColorOpen={isFontColorOpen}>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorWhiteIcn />
+              <TextColorText>white</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorGrayIcn />
+              <TextColorText>gray</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorRedIcn />
+              <TextColorText>red</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorOrangeIcn />
+              <TextColorText>orange</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorYellowIcn />
+              <TextColorText>yellow</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorGreenIcn />
+              <TextColorText>green</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorBlueIcn />
+              <TextColorText>blue</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorVioletIcn />
+              <TextColorText>violet</TextColorText>
+            </TextColorOptionWrapper>
+            <TextColorOptionWrapper>
+              <EditorTextBgColorPinkIcn />
+              <TextColorText>pink</TextColorText>
+            </TextColorOptionWrapper>
+          </TextColorList>
+        </ToolbarDropDownWrapper>
         <button
           className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
           onClick={toggleHighLightWhite}
@@ -600,7 +653,7 @@ const ToolbarWrapper = styled.div`
   border-radius: 0.8rem;
 `;
 
-// 글자 크기 드롭다운 리스트
+// 드롭다운 리스트
 const ToolbarDropDownWrapper = styled.div`
   position: relative;
   z-index: 3;
@@ -612,6 +665,7 @@ const ToolbarDropDownWrapper = styled.div`
   cursor: pointer;
 `;
 
+// 글자 크기 드롭다운 리스트
 const FontSizeToggle = styled.div`
   display: flex;
   gap: 0.8rem;

--- a/src/pages/postPage/components/TipTap.tsx
+++ b/src/pages/postPage/components/TipTap.tsx
@@ -68,6 +68,8 @@ const TipTap = (props: EditorPropTypes) => {
   const [isFontSizeOpen, setIsFontSizeOpen] = useState(false);
   // font color drop down
   const [isFontColorOpen, setIsFontColorOpen] = useState(false);
+  // font background color drop down
+  const [isFontBgColorOpen, setIsFontBgColorOpen] = useState(false);
 
   const onClickFontSizeToggle = () => {
     setIsFontSizeOpen(!isFontSizeOpen);
@@ -76,6 +78,11 @@ const TipTap = (props: EditorPropTypes) => {
 
   const onClickFontColorToggle = () => {
     setIsFontColorOpen(!isFontColorOpen);
+    setIsToggleOpen(!isToggleOpen);
+  };
+
+  const onClickFontBgColorToggle = () => {
+    setIsFontBgColorOpen(!isFontBgColorOpen);
     setIsToggleOpen(!isToggleOpen);
   };
 
@@ -189,30 +196,39 @@ const TipTap = (props: EditorPropTypes) => {
   // 글자 배경색 함수
   const toggleHighLightWhite = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#FFFFFF' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightGray = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#EAEAEA' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightRed = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#F6E2E2' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightOrange = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#F6E7E2' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightYellow = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#F6F4E2' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightGreen = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#F1F6E2' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightBlue = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#E2EAF6' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightViolet = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#E9E3F8' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
   const toggleHighLightPink = useCallback(() => {
     editor.chain().focus().toggleHighlight({ color: '#F6E2F3' }).run();
+    setIsFontBgColorOpen(false);
   }, [editor]);
 
   // bold 함수
@@ -443,7 +459,7 @@ const TipTap = (props: EditorPropTypes) => {
 
         {/* 글자 배경색 */}
         <ToolbarDropDownWrapper>
-          <TextColorToggle>
+          <TextColorToggle onClick={onClickFontBgColorToggle}>
             {editor.isActive('highlight', { color: '#FFFFFF' }) ? (
               <EditorTextBgColorWhiteIcn />
             ) : editor.isActive('highlight', { color: '#EAEAEA' }) ? (
@@ -465,9 +481,9 @@ const TipTap = (props: EditorPropTypes) => {
             ) : (
               <EditorTextBgColorWhiteIcn />
             )}
-            {isFontSizeOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
+            {isFontBgColorOpen ? <EditorDropIcnOpen /> : <EditorDropIcnClose />}
           </TextColorToggle>
-          <TextColorList $isFontColorOpen={isFontColorOpen}>
+          <TextColorBgList $isFontBgColorOpen={isFontBgColorOpen}>
             <TextColorOptionWrapper onClick={toggleHighLightWhite}>
               <EditorTextBgColorWhiteIcn
                 className={editor.isActive('highlight', { color: '#FFFFFF' }) ? 'is-active' : ''}
@@ -558,7 +574,7 @@ const TipTap = (props: EditorPropTypes) => {
                 pink
               </TextColorText>
             </TextColorOptionWrapper>
-          </TextColorList>
+          </TextColorBgList>
         </ToolbarDropDownWrapper>
 
         {/* bold */}
@@ -757,6 +773,23 @@ const TextColorList = styled.div<{ $isFontColorOpen: boolean }>`
   top: 2.9rem;
 
   display: ${({ $isFontColorOpen }) => ($isFontColorOpen ? 'flex' : 'none')};
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-start;
+  width: 11.6rem;
+  padding: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.gray50};
+  border-radius: 10px;
+`;
+
+const TextColorBgList = styled.div<{ $isFontBgColorOpen: boolean }>`
+  position: absolute;
+  top: 2.9rem;
+
+  display: ${({ $isFontBgColorOpen }) => ($isFontBgColorOpen ? 'flex' : 'none')};
   flex-direction: column;
   gap: 0.6rem;
   align-items: center;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #239 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 에디터 툴바 글자 배경 색상 변경 뷰 커스텀

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 역시나 딱히 없고 [이전 PR](https://github.com/Mile-Writings/Mile-Client/pull/235)과 같은 로직으로 구현했슴니다.
- 역시나 PR 쪼개는 중 잘했쥬 ?
- 239 브랜치 커밋만 반영하려고 base 브랜치 변경해두었습니다. 머지할 때 확인하기~

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
```typescript
const TextColorList = styled.div<{ $isFontColorOpen: boolean }>`
  position: absolute;
  top: 2.9rem;

  display: ${({ $isFontColorOpen }) => ($isFontColorOpen ? 'flex' : 'none')};
  flex-direction: column;
  gap: 0.6rem;
  align-items: center;
  justify-content: flex-start;
  width: 11.6rem;
  padding: 1rem;

  background-color: ${({ theme }) => theme.colors.white};
  border: 1px solid ${({ theme }) => theme.colors.gray50};
  border-radius: 10px;
`;

const TextColorBgList = styled.div<{ $isFontBgColorOpen: boolean }>`
  position: absolute;
  top: 2.9rem;

  display: ${({ $isFontBgColorOpen }) => ($isFontBgColorOpen ? 'flex' : 'none')};
  flex-direction: column;
  gap: 0.6rem;
  align-items: center;
  justify-content: flex-start;
  width: 11.6rem;
  padding: 1rem;

  background-color: ${({ theme }) => theme.colors.white};
  border: 1px solid ${({ theme }) => theme.colors.gray50};
  border-radius: 10px;
`;
```
여기 보면 `TextColorList`랑 `TextColorBgList`랑 사실 css 코드는 전부 다 같은데, 전달받는 prop이 `isFontColorOpen`와 `isFontBgColorOpen`로 달라서 두 개로 분리해서 구현하였습니다.

컴포넌트를 하나만 만들고 prop을 2개 전달받을 수 있게하고, 둘 중 필요한 prop을 선택적으로 전달할 수 있도록해서 재사용성을 높이고 싶은데.. 일단 prop을 2개 전달받는데 선택적으로 하나만 전달하면 에러가 나더라구요 .. 

이렇게 prop이 다르다는 이유로 같은 css 코드를 냅다 두 번 써서 컴포넌트를 만드는게 최선의 방법일까요 .. 라는 질문.. 

## 📌스크린샷(선택)

https://github.com/Mile-Writings/Mile-Client/assets/109661444/3dac2ba4-9c1a-4c6f-b761-bc1dcecdf394

