### PR TITLE
[Fix/#242] login routing to before

### DIFF
--- a/src/pages/groupFeed/components/GroupFeedHeader.tsx
+++ b/src/pages/groupFeed/components/GroupFeedHeader.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import MakeGroupBtn from './MakeGroupBtn';
 import MyGroupBtn from './MyGroupBtn';
@@ -52,6 +52,8 @@ export const GroupFeedHeader = () => {
 //아직 로그인을 하지 않았을 때 헤더
 export const LogOutHeader = ({ onClick }: OnClickProps) => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  localStorage.setItem('history', pathname);
   const handleMainRouting = () => {
     navigate('/');
   };

--- a/src/pages/login/RedirectLogin.tsx
+++ b/src/pages/login/RedirectLogin.tsx
@@ -6,7 +6,7 @@ import Loading from '../loading/Loading';
 
 const RedirectLogin = () => {
   const code: string = new URL(window.location.href).searchParams.get('code') || '';
-
+  window.history.forward();
   const { mutate } = useLoginService({ code, socialType: 'KAKAO' });
   useEffect(() => {
     mutate();

--- a/src/pages/login/RedirectLogin.tsx
+++ b/src/pages/login/RedirectLogin.tsx
@@ -6,7 +6,7 @@ import Loading from '../loading/Loading';
 
 const RedirectLogin = () => {
   const code: string = new URL(window.location.href).searchParams.get('code') || '';
-  console.log(code);
+
   const { mutate } = useLoginService({ code, socialType: 'KAKAO' });
   useEffect(() => {
     mutate();
@@ -15,26 +15,3 @@ const RedirectLogin = () => {
 };
 
 export default RedirectLogin;
-// axios로 구현한거 refactoring한 부분이라 남겨둘게요~
-// useEffect(() => {
-//   const fetchData = async () => {
-//     try {
-//       const { accessToken } = await loginService({
-//         authorizationCode: code,
-//         socialType: 'KAKAO',
-//       });
-
-//       if (accessToken) {
-//         console.log(accessToken);
-//         localStorage.setItem('accessToken', accessToken);
-//         navigate('/');
-//       } else {
-//         console.error('No data received from loginService');
-//       }
-//     } catch (e) {
-//       console.error(e);
-//     }
-//   };
-
-//   fetchData();
-// }, [code]);

--- a/src/pages/login/hooks/useLoginService.ts
+++ b/src/pages/login/hooks/useLoginService.ts
@@ -4,14 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import loginService from '../apis/loginService';
 import { LoginProps } from '../types/loginType';
-//추후 타입 필요할 지도 몰라서 넣어둠
-// interface LoginType {
-//   status: number;
-//   message: string;
-//   data: {
-//     accessToken: string;
-//   };
-// }
+
 export const useLoginService = ({ code, socialType }: LoginProps) => {
   const navigate = useNavigate();
   // const queryClient = useQueryClient();
@@ -22,7 +15,11 @@ export const useLoginService = ({ code, socialType }: LoginProps) => {
       console.log('success');
       // queryClient.invalidateQueries({ queryKey: ['products'] });
       localStorage.setItem('accessToken', data.accessToken);
-      navigate('/');
+      if (localStorage.getItem('history')) {
+        navigate(`${localStorage.getItem('history')}`);
+      } else {
+        navigate('/');
+      }
     },
     onError: (err) => {
       if (isAxiosError(err) && err.response?.status) {

--- a/src/pages/main/components/Carousel.tsx
+++ b/src/pages/main/components/Carousel.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Slider from 'react-slick';
 
 import '../styles/slick-theme.css';
@@ -14,7 +14,6 @@ import { groupPropTypes } from '../types/groupContent';
 import Spacing from './../../../components/commons/Spacing';
 import getGroupContentApi from './../../../utils/apis/getGroupContentApi';
 
-
 const Carousel = () => {
   const [groupData, setGroupData] = useState<groupPropTypes[]>();
   const settings = {
@@ -25,17 +24,19 @@ const Carousel = () => {
     slidesToShow: 1,
     slidesToScroll: 1,
   };
+  useEffect(() => {
+    const getData = async () => {
+      try {
+        const data = await getGroupContentApi();
+        setGroupData(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    getData();
+  }, []);
 
-  const getData = async () => {
-    try {
-      const data = await getGroupContentApi();
-      setGroupData(data);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-  getData();
-
+  console.log('first');
   return (
     <>
       {groupData ? (

--- a/src/pages/main/components/MainHeader.tsx
+++ b/src/pages/main/components/MainHeader.tsx
@@ -8,7 +8,6 @@ import theme from '../../../styles/theme';
 import logout from '../../../utils/logout';
 import MakeGroupBtn from '../../groupFeed/components/MakeGroupBtn';
 import MyGroupBtn from '../../groupFeed/components/MyGroupBtn';
-
 // 메인 페이지 헤더
 export const AuthorizationHeader = () => {
   const { navigateToHome } = useNavigateToHome();
@@ -35,9 +34,10 @@ export const AuthorizationHeader = () => {
 export const UnAuthorizationHeader = () => {
   const navigate = useNavigate();
   const { navigateToHome } = useNavigateToHome();
-  const pathname = useLocation();
+  const { pathname } = useLocation();
+  localStorage.setItem('history', pathname);
   const handleLogIn = () => {
-    navigate(`/login`, { state: pathname });
+    navigate(`/login`);
   };
   return (
     <HeaderWrapper>

--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -118,10 +118,9 @@ const PostDetail = () => {
               <WriterDesc>{postData?.writerInfo && '아직 작가소개를 작성하지 않았어요'}</WriterDesc>
             </InfoWrapper>
           </WriterInfoContainer>
-          <CuriousBtn />
+          {localStorage.accessToken && <CuriousBtn />}
         </WriterInfoWrapper>
-
-        <Comment postId={postId} />
+        {localStorage.accessToken && <Comment postId={postId} />}
         <Spacing marginBottom="8" />
       </PostDetailWrapper>
     </>

--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -57,14 +57,6 @@ const PostDetail = () => {
       },
     });
   };
-  // 리팩토링 전 코드
-  // useEffect(() => {
-  //   if (typeof postId === 'string') {
-  //     const data = fetchPostDetail(postId);
-  //     console.log(data);
-  //   }
-  // }, []);
-  // console.log(postAuth?.data?.data.canEdit);
 
   return (
     <>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #242 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 로그인시 이전에 유저가 있던 페이지로 리다이렉트 (localStorage사용)
- [x] 로그인 이후 뒤로가기를 막아 redirect login 페이지 접근 불가하도록 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
-   window.history.forward(); 써져있는 페이지로는 뒤로가기 불가

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
- 헤더 같은 기능으로 두개가 똑같이 있고 컴포넌트명이 헷갈리게 되어있어서 리팩토링이 필요할 것 같습니다 !

## 📌스크린샷(선택)

https://github.com/Mile-Writings/Mile-Client/assets/81609304/40e6fa28-fda3-4b38-bf3b-ce9461b5121e

