### PR TITLE
[Feat/#262] 공통 모달 구현

### DIFF
--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,90 +1,55 @@
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Spacing from './Spacing';
 
-interface modalContentPropTypes {
+interface ModalContentPropTypes {
   modalContent: string;
-  confirmRoutingTo: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  positiveBtnHandler: () => void;
   setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-interface ButtonPropTypes {
-  confirmRoutingTo: string;
-  children: string;
-  setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
 // '아니오'를 유도하는 모달
-export const NegativeModal = (props: modalContentPropTypes) => {
-  const { confirmRoutingTo, modalContent } = props;
+export const NegativeModal = (props: ModalContentPropTypes) => {
+  const { modalContent, positiveBtnHandler } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
+  const negativeBtnHandler = () => {
+    setIsVisible(false);
+  };
 
   return (
     <ModalWrapper $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <NegativeBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
-          예
-        </NegativeBtn>
-        <PositiveBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
-          아니오
-        </PositiveBtn>
+        <NegativeButton onClick={positiveBtnHandler}>예</NegativeButton>
+        <PositiveButton onClick={negativeBtnHandler}>아니오</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
 // '예'를 유도하는 모달
-export const PositiveModal = (props: modalContentPropTypes) => {
-  const { confirmRoutingTo, modalContent } = props;
+export const PositiveModal = (props: ModalContentPropTypes) => {
+  const { modalContent, positiveBtnHandler } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
+  const negativeBtnHandler = () => {
+    setIsVisible(false);
+    console.log('close');
+  };
 
   return (
     <ModalWrapper $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <NegativeBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
-          아니오
-        </NegativeBtn>
-        <PositiveBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
-          예
-        </PositiveBtn>
+        <NegativeButton onClick={negativeBtnHandler}>아니오</NegativeButton>
+        <PositiveButton onClick={positiveBtnHandler}>예</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
-export const PositiveBtn = (props: ButtonPropTypes) => {
-  const { children, confirmRoutingTo } = props;
-  const navigate = useNavigate();
-  const handleOnClick = () => {
-    if (children === '아니오') {
-      props.setIsVisible(false);
-    } else {
-      navigate(`${confirmRoutingTo}`);
-    }
-  };
-
-  return <PositiveButton onClick={handleOnClick}>{children}</PositiveButton>;
-};
-
-export const NegativeBtn = (props: ButtonPropTypes) => {
-  const { children, confirmRoutingTo } = props;
-  const navigate = useNavigate();
-  const handleOnClick = () => {
-    if (children === '아니오') {
-      props.setIsVisible(false);
-    } else {
-      navigate(`${confirmRoutingTo}`);
-    }
-  };
-
-  return <NegativeButton onClick={handleOnClick}>{children}</NegativeButton>;
-};
 const ModalWrapper = styled.section<{ $isVisible: boolean }>`
   display: ${({ $isVisible }) => ($isVisible ? 'flex' : 'none')};
   flex-direction: column;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import Spacing from './Spacing';
+
 interface modalPropTypes {
   modalContent: string;
 }
@@ -14,6 +16,7 @@ export const NegativeModal = ({ modalContent }: modalPropTypes) => {
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
+      <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
         <ModalButton buttonContent={'예'} isRightButton={false} />
         <ModalButton buttonContent={'아니오'} isRightButton={true} />
@@ -27,6 +30,7 @@ export const PositiveModal = ({ modalContent }: modalPropTypes) => {
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
+      <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
         <ModalButton buttonContent={'아니오'} isRightButton={false} />
         <ModalButton buttonContent={'예'} isRightButton={true} />
@@ -46,15 +50,23 @@ const ModalWrapper = styled.section`
   justify-content: center;
   width: 40rem;
   height: 18.1rem;
+  padding: 3.2rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: 1rem;
 `;
 
 const ModalContentLayout = styled.div`
-  gap: 1.2rem;
-  align-items: center;
+  color: ${({ theme }) => theme.colors.gray100};
+  white-space: pre-line;
+  text-align: center;
+
+  ${({ theme }) => theme.fonts.title8};
 `;
 
 const ModalBtnLayout = styled.div`
   display: flex;
+  gap: 1.2rem;
 `;
 
 const ModalBtnWrapper = styled.button<{ $isRightButton: boolean }>`
@@ -67,11 +79,16 @@ const ModalBtnWrapper = styled.button<{ $isRightButton: boolean }>`
 
   background-color: ${({ $isRightButton, theme }) =>
     $isRightButton ? theme.colors.mainViolet : theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.mainViolet};
+  border: 1px solid
+    ${({ $isRightButton, theme }) =>
+      $isRightButton ? theme.colors.mileViolet : theme.colors.mainViolet};
+  border-radius: 0.8rem;
 
   ${({ theme }) => theme.fonts.button2};
 
   &:hover {
+    color: ${({ theme }) => theme.colors.mainViolet};
+
     background-color: ${({ theme }) => theme.colors.mileViolet};
   }
 `;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import Spacing from './Spacing';
+
+import useClickOutside from '../../hooks/useClickOutside';
 
 interface ModalContentPropTypes {
   modalContent: string;
@@ -13,17 +15,19 @@ interface ModalContentPropTypes {
 export const NegativeModal = (props: ModalContentPropTypes) => {
   const { modalContent, onClick } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
-  const negativeBtnHandler = () => {
+  const modalRef = useRef(null);
+  const closeModalHandler = () => {
     setIsVisible(false);
   };
+  useClickOutside(modalRef, closeModalHandler);
 
   return (
-    <ModalWrapper $isVisible={isVisible}>
+    <ModalWrapper ref={modalRef} $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
         <NegativeButton onClick={onClick}>예</NegativeButton>
-        <PositiveButton onClick={negativeBtnHandler}>아니오</PositiveButton>
+        <PositiveButton onClick={closeModalHandler}>아니오</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -33,16 +37,20 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
 export const PositiveModal = (props: ModalContentPropTypes) => {
   const { modalContent, onClick } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
-  const negativeBtnHandler = () => {
+  const modalRef = useRef(null);
+
+  const closeModalHandler = () => {
     setIsVisible(false);
   };
 
+  useClickOutside(modalRef, closeModalHandler);
+
   return (
-    <ModalWrapper $isVisible={isVisible}>
+    <ModalWrapper ref={modalRef} $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <NegativeButton onClick={negativeBtnHandler}>아니오</NegativeButton>
+        <NegativeButton onClick={closeModalHandler}>아니오</NegativeButton>
         <PositiveButton onClick={onClick}>예</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -6,35 +6,29 @@ import Spacing from './Spacing';
 interface modalContentPropTypes {
   modalContent: string;
   confirmRoutingTo: string;
-  cancelRoutingTo: string;
+  // cancelRoutingTo: string;
 }
 
 interface ButtonPropTypes {
-  buttonContent: string;
+  children: string;
   isRightButton: boolean; // 버튼이 오른쪽에 있는지 여부
   confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
-  cancelRoutingTo?: string | undefined; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
+  // cancelRoutingTo?: string | undefined; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
 }
 
 // '아니오'를 유도하는 모달
 export const NegativeModal = (props: modalContentPropTypes) => {
-  const { confirmRoutingTo, cancelRoutingTo, modalContent } = props;
+  const { confirmRoutingTo, modalContent } = props;
 
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton
-          confirmRoutingTo={confirmRoutingTo}
-          buttonContent={'예'}
-          isRightButton={false}
-        />
-        <ModalButton
-          cancelRoutingTo={cancelRoutingTo}
-          buttonContent={'아니오'}
-          isRightButton={true}
-        />
+        <ModalButton confirmRoutingTo={confirmRoutingTo} isRightButton={false}>
+          예
+        </ModalButton>
+        <ModalButton isRightButton={true}>아니오</ModalButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -42,42 +36,34 @@ export const NegativeModal = (props: modalContentPropTypes) => {
 
 // '예'를 유도하는 모달
 export const PositiveModal = (props: modalContentPropTypes) => {
-  const { confirmRoutingTo, cancelRoutingTo, modalContent } = props;
+  const { confirmRoutingTo, modalContent } = props;
 
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton
-          cancelRoutingTo={cancelRoutingTo}
-          buttonContent={'아니오'}
-          isRightButton={false}
-        />
-        <ModalButton
-          confirmRoutingTo={confirmRoutingTo}
-          buttonContent={'예'}
-          isRightButton={true}
-        />
+        <ModalButton isRightButton={false}>아니오</ModalButton>
+        <ModalButton confirmRoutingTo={confirmRoutingTo} isRightButton={true}>
+          예
+        </ModalButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
 export const ModalButton = (props: ButtonPropTypes) => {
-  const { confirmRoutingTo, cancelRoutingTo, buttonContent, isRightButton } = props;
+  const { confirmRoutingTo, children, isRightButton } = props;
   const navigate = useNavigate();
   const handleOnClick = () => {
     if (confirmRoutingTo) {
       navigate(`${confirmRoutingTo}`);
-    } else if (cancelRoutingTo) {
-      navigate(`${cancelRoutingTo}`);
     }
   };
 
   return (
     <ModalBtnWrapper onClick={handleOnClick} $isRightButton={isRightButton}>
-      {buttonContent}
+      {children}
     </ModalBtnWrapper>
   );
 };

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -5,6 +5,7 @@ interface modalPropTypes {
 }
 
 interface ButtonPropTypes {
+  buttonContent: string;
   isRightButton: boolean;
 }
 
@@ -14,8 +15,8 @@ export const NegativeModal = ({ modalContent }: modalPropTypes) => {
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <ModalBtnLayout>
-        <PositiveBtn isRightButton={false} />
-        <NegativeBtn isRightButton={true} />
+        <ModalButton buttonContent={'예'} isRightButton={false} />
+        <ModalButton buttonContent={'아니오'} isRightButton={true} />
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -27,19 +28,15 @@ export const PositiveModal = ({ modalContent }: modalPropTypes) => {
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <ModalBtnLayout>
-        <NegativeBtn isRightButton={false} />
-        <PositiveBtn isRightButton={true} />
+        <ModalButton buttonContent={'아니오'} isRightButton={false} />
+        <ModalButton buttonContent={'예'} isRightButton={true} />
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
-export const PositiveBtn = ({ isRightButton }: ButtonPropTypes) => {
-  return <ModalBtnWrapper $isRightButton={isRightButton}>예</ModalBtnWrapper>;
-};
-
-export const NegativeBtn = ({ isRightButton }: ButtonPropTypes) => {
-  return <ModalBtnWrapper $isRightButton={isRightButton}>아니오</ModalBtnWrapper>;
+export const ModalButton = ({ buttonContent, isRightButton }: ButtonPropTypes) => {
+  return <ModalBtnWrapper $isRightButton={isRightButton}>{buttonContent}</ModalBtnWrapper>;
 };
 
 const ModalWrapper = styled.section`

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -13,7 +13,7 @@ interface modalContentPropTypes {
 interface ButtonPropTypes {
   setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
   children: string;
-  confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  confirmRoutingTo?: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
 }
 
 // '아니오'를 유도하는 모달

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -5,15 +5,15 @@ import Spacing from './Spacing';
 
 interface modalContentPropTypes {
   modalContent: string;
-  confirmRoutingTo: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  confirmRoutingTo: string;
   cancelRoutingTo: string;
 }
 
 interface ButtonPropTypes {
   buttonContent: string;
-  isRightButton: boolean; // 어느 버튼이 오른쪽에 있는지 나타냄
-  confirmRoutingTo?: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
-  cancelRoutingTo?: string; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
+  isRightButton: boolean; // 버튼이 오른쪽에 있는지 여부
+  confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  cancelRoutingTo?: string | undefined; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
 }
 
 // '아니오'를 유도하는 모달
@@ -64,9 +64,10 @@ export const PositiveModal = (props: modalContentPropTypes) => {
   );
 };
 
-export const ModalButton = ({ buttonContent, isRightButton }: ButtonPropTypes) => {
+export const ModalButton = (props: ButtonPropTypes) => {
+  const { confirmRoutingTo, cancelRoutingTo, buttonContent, isRightButton } = props;
   const navigate = useNavigate();
-  const handleOnClick = ({ confirmRoutingTo, cancelRoutingTo }: ButtonPropTypes) => {
+  const handleOnClick = () => {
     if (confirmRoutingTo) {
       navigate(`${confirmRoutingTo}`);
     } else if (cancelRoutingTo) {
@@ -75,7 +76,7 @@ export const ModalButton = ({ buttonContent, isRightButton }: ButtonPropTypes) =
   };
 
   return (
-    <ModalBtnWrapper onClick={() => handleOnClick} $isRightButton={isRightButton}>
+    <ModalBtnWrapper onClick={handleOnClick} $isRightButton={isRightButton}>
       {buttonContent}
     </ModalBtnWrapper>
   );

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -35,7 +35,6 @@ export const PositiveModal = (props: ModalContentPropTypes) => {
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const negativeBtnHandler = () => {
     setIsVisible(false);
-    console.log('close');
   };
 
   return (

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,46 +1,84 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 import Spacing from './Spacing';
 
-interface modalPropTypes {
+interface modalContentPropTypes {
   modalContent: string;
+  confirmRoutingTo: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  cancelRoutingTo: string;
 }
 
 interface ButtonPropTypes {
   buttonContent: string;
-  isRightButton: boolean;
+  isRightButton: boolean; // 어느 버튼이 오른쪽에 있는지 나타냄
+  confirmRoutingTo?: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  cancelRoutingTo?: string; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
 }
 
 // '아니오'를 유도하는 모달
-export const NegativeModal = ({ modalContent }: modalPropTypes) => {
+export const NegativeModal = (props: modalContentPropTypes) => {
+  const { confirmRoutingTo, cancelRoutingTo, modalContent } = props;
+
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton buttonContent={'예'} isRightButton={false} />
-        <ModalButton buttonContent={'아니오'} isRightButton={true} />
+        <ModalButton
+          confirmRoutingTo={confirmRoutingTo}
+          buttonContent={'예'}
+          isRightButton={false}
+        />
+        <ModalButton
+          cancelRoutingTo={cancelRoutingTo}
+          buttonContent={'아니오'}
+          isRightButton={true}
+        />
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
 // '예'를 유도하는 모달
-export const PositiveModal = ({ modalContent }: modalPropTypes) => {
+export const PositiveModal = (props: modalContentPropTypes) => {
+  const { confirmRoutingTo, cancelRoutingTo, modalContent } = props;
+
   return (
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton buttonContent={'아니오'} isRightButton={false} />
-        <ModalButton buttonContent={'예'} isRightButton={true} />
+        <ModalButton
+          cancelRoutingTo={cancelRoutingTo}
+          buttonContent={'아니오'}
+          isRightButton={false}
+        />
+        <ModalButton
+          confirmRoutingTo={confirmRoutingTo}
+          buttonContent={'예'}
+          isRightButton={true}
+        />
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
 export const ModalButton = ({ buttonContent, isRightButton }: ButtonPropTypes) => {
-  return <ModalBtnWrapper $isRightButton={isRightButton}>{buttonContent}</ModalBtnWrapper>;
+  const navigate = useNavigate();
+  const handleOnClick = ({ confirmRoutingTo, cancelRoutingTo }: ButtonPropTypes) => {
+    if (confirmRoutingTo) {
+      navigate(`${confirmRoutingTo}`);
+    } else if (cancelRoutingTo) {
+      navigate(`${cancelRoutingTo}`);
+    }
+  };
+
+  return (
+    <ModalBtnWrapper onClick={() => handleOnClick} $isRightButton={isRightButton}>
+      {buttonContent}
+    </ModalBtnWrapper>
+  );
 };
 
 const ModalWrapper = styled.section`

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+import { NegativeBtn, PositiveBtn } from './ModalBtn';
+
+interface modalPropTypes {
+  modalContent: string;
+}
+
+// '아니오'를 유도하는 모달
+export const NegativeModal = ({ modalContent }: modalPropTypes) => {
+  return (
+    <ModalWrapper>
+      <ModalContentLayout>{modalContent}</ModalContentLayout>
+      <ModalBtnLayout>
+        <PositiveBtn />
+        <NegativeBtn />
+      </ModalBtnLayout>
+    </ModalWrapper>
+  );
+};
+
+// '예'를 유도하는 모달
+export const PositiveModal = ({ modalContent }: modalPropTypes) => {
+  return (
+    <ModalWrapper>
+      <ModalContentLayout>{modalContent}</ModalContentLayout>
+      <ModalBtnLayout>
+        <NegativeBtn >
+        <PositiveBtn />
+      </ModalBtnLayout>
+    </ModalWrapper>
+  );
+};
+
+const ModalWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 40rem;
+  height: 18.1rem;
+`;
+
+const ModalContentLayout = styled.div`
+  gap: 1.2rem;
+  align-items: center;
+`;
+
+const ModalBtnLayout = styled.div`
+  display: flex;
+`;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -6,14 +6,14 @@ import Spacing from './Spacing';
 
 interface modalContentPropTypes {
   modalContent: string;
-  confirmRoutingTo: string;
+  confirmRoutingTo: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
   setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 interface ButtonPropTypes {
-  setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
+  confirmRoutingTo: string;
   children: string;
-  confirmRoutingTo?: string; // '예' 버튼이 라우팅 되는 곳을 나타냄
+  setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // '아니오'를 유도하는 모달
@@ -26,10 +26,12 @@ export const NegativeModal = (props: modalContentPropTypes) => {
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <LeftBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+        <NegativeBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
           예
-        </LeftBtn>
-        <RightBtn setIsVisible={setIsVisible}>아니오</RightBtn>
+        </NegativeBtn>
+        <PositiveBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+          아니오
+        </PositiveBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -45,47 +47,44 @@ export const PositiveModal = (props: modalContentPropTypes) => {
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <LeftBtn setIsVisible={setIsVisible}>아니오</LeftBtn>
-        <RightBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+        <NegativeBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+          아니오
+        </NegativeBtn>
+        <PositiveBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
           예
-        </RightBtn>
+        </PositiveBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
-export const RightBtn = (props: ButtonPropTypes) => {
-  const { confirmRoutingTo, children } = props;
+export const PositiveBtn = (props: ButtonPropTypes) => {
+  const { children, confirmRoutingTo } = props;
   const navigate = useNavigate();
-  const [, setIsVisible] = useState<boolean>(true);
-
   const handleOnClick = () => {
-    if (confirmRoutingTo) {
-      navigate(`${confirmRoutingTo}`);
+    if (children === '아니오') {
+      props.setIsVisible(false);
     } else {
-      setIsVisible(false);
+      navigate(`${confirmRoutingTo}`);
     }
   };
 
-  return <RightButton onClick={handleOnClick}>{children}</RightButton>;
+  return <PositiveButton onClick={handleOnClick}>{children}</PositiveButton>;
 };
 
-export const LeftBtn = (props: ButtonPropTypes) => {
-  const { confirmRoutingTo, children } = props;
-  const [, setIsVisible] = useState<boolean>(true);
+export const NegativeBtn = (props: ButtonPropTypes) => {
+  const { children, confirmRoutingTo } = props;
   const navigate = useNavigate();
-
   const handleOnClick = () => {
-    if (confirmRoutingTo) {
-      navigate(`${confirmRoutingTo}`);
+    if (children === '아니오') {
+      props.setIsVisible(false);
     } else {
-      setIsVisible(true);
+      navigate(`${confirmRoutingTo}`);
     }
   };
 
-  return <LeftButton onClick={handleOnClick}>{children}</LeftButton>;
+  return <NegativeButton onClick={handleOnClick}>{children}</NegativeButton>;
 };
-
 const ModalWrapper = styled.section<{ $isVisible: boolean }>`
   display: ${({ $isVisible }) => ($isVisible ? 'flex' : 'none')};
   flex-direction: column;
@@ -112,7 +111,7 @@ const ModalBtnLayout = styled.div`
   gap: 1.2rem;
 `;
 
-const RightButton = styled.button`
+const PositiveButton = styled.button`
   width: 15.4rem;
   height: 3.9rem;
   padding: 1rem 0;
@@ -131,7 +130,7 @@ const RightButton = styled.button`
   }
 `;
 
-const LeftButton = styled.button`
+const NegativeButton = styled.button`
   width: 15.4rem;
   height: 3.9rem;
   padding: 1rem 0;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
 
-import { NegativeBtn, PositiveBtn } from './ModalBtn';
-
 interface modalPropTypes {
   modalContent: string;
+}
+
+interface ButtonPropTypes {
+  isRightButton: boolean;
 }
 
 // '아니오'를 유도하는 모달
@@ -12,8 +14,8 @@ export const NegativeModal = ({ modalContent }: modalPropTypes) => {
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <ModalBtnLayout>
-        <PositiveBtn />
-        <NegativeBtn />
+        <PositiveBtn isRightButton={false} />
+        <NegativeBtn isRightButton={true} />
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -25,11 +27,19 @@ export const PositiveModal = ({ modalContent }: modalPropTypes) => {
     <ModalWrapper>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <ModalBtnLayout>
-        <NegativeBtn >
-        <PositiveBtn />
+        <NegativeBtn isRightButton={false} />
+        <PositiveBtn isRightButton={true} />
       </ModalBtnLayout>
     </ModalWrapper>
   );
+};
+
+export const PositiveBtn = ({ isRightButton }: ButtonPropTypes) => {
+  return <ModalBtnWrapper $isRightButton={isRightButton}>예</ModalBtnWrapper>;
+};
+
+export const NegativeBtn = ({ isRightButton }: ButtonPropTypes) => {
+  return <ModalBtnWrapper $isRightButton={isRightButton}>아니오</ModalBtnWrapper>;
 };
 
 const ModalWrapper = styled.section`
@@ -48,4 +58,23 @@ const ModalContentLayout = styled.div`
 
 const ModalBtnLayout = styled.div`
   display: flex;
+`;
+
+const ModalBtnWrapper = styled.button<{ $isRightButton: boolean }>`
+  width: 15.4rem;
+  height: 3.9rem;
+  padding: 1rem 0;
+
+  color: ${({ $isRightButton, theme }) =>
+    $isRightButton ? theme.colors.white : theme.colors.mainViolet};
+
+  background-color: ${({ $isRightButton, theme }) =>
+    $isRightButton ? theme.colors.mainViolet : theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.mainViolet};
+
+  ${({ theme }) => theme.fonts.button2};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.mileViolet};
+  }
 `;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -6,13 +6,11 @@ import Spacing from './Spacing';
 interface modalContentPropTypes {
   modalContent: string;
   confirmRoutingTo: string;
-  // cancelRoutingTo: string;
 }
 
 interface ButtonPropTypes {
   children: string;
   confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
-  // cancelRoutingTo?: string | undefined; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
 }
 
 // '아니오'를 유도하는 모달

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Spacing from './Spacing';
@@ -6,9 +7,11 @@ import Spacing from './Spacing';
 interface modalContentPropTypes {
   modalContent: string;
   confirmRoutingTo: string;
+  setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 interface ButtonPropTypes {
+  setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
   children: string;
   confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
 }
@@ -16,14 +19,17 @@ interface ButtonPropTypes {
 // '아니오'를 유도하는 모달
 export const NegativeModal = (props: modalContentPropTypes) => {
   const { confirmRoutingTo, modalContent } = props;
+  const [isVisible, setIsVisible] = useState<boolean>(true);
 
   return (
-    <ModalWrapper>
+    <ModalWrapper $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <LeftBtn confirmRoutingTo={confirmRoutingTo}>예</LeftBtn>
-        <RightBtn>아니오</RightBtn>
+        <LeftBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+          예
+        </LeftBtn>
+        <RightBtn setIsVisible={setIsVisible}>아니오</RightBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -32,14 +38,17 @@ export const NegativeModal = (props: modalContentPropTypes) => {
 // '예'를 유도하는 모달
 export const PositiveModal = (props: modalContentPropTypes) => {
   const { confirmRoutingTo, modalContent } = props;
+  const [isVisible, setIsVisible] = useState<boolean>(true);
 
   return (
-    <ModalWrapper>
+    <ModalWrapper $isVisible={isVisible}>
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <LeftBtn>아니오</LeftBtn>
-        <RightBtn confirmRoutingTo={confirmRoutingTo}>예</RightBtn>
+        <LeftBtn setIsVisible={setIsVisible}>아니오</LeftBtn>
+        <RightBtn setIsVisible={setIsVisible} confirmRoutingTo={confirmRoutingTo}>
+          예
+        </RightBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -48,29 +57,37 @@ export const PositiveModal = (props: modalContentPropTypes) => {
 export const RightBtn = (props: ButtonPropTypes) => {
   const { confirmRoutingTo, children } = props;
   const navigate = useNavigate();
+  const [, setIsVisible] = useState<boolean>(true);
+
   const handleOnClick = () => {
     if (confirmRoutingTo) {
       navigate(`${confirmRoutingTo}`);
+    } else {
+      setIsVisible(false);
     }
   };
 
-  return <RightBtnWrapper onClick={handleOnClick}>{children}</RightBtnWrapper>;
+  return <RightButton onClick={handleOnClick}>{children}</RightButton>;
 };
 
 export const LeftBtn = (props: ButtonPropTypes) => {
   const { confirmRoutingTo, children } = props;
+  const [, setIsVisible] = useState<boolean>(true);
   const navigate = useNavigate();
+
   const handleOnClick = () => {
     if (confirmRoutingTo) {
       navigate(`${confirmRoutingTo}`);
+    } else {
+      setIsVisible(true);
     }
   };
 
-  return <LeftBtnWrapper onClick={handleOnClick}>{children}</LeftBtnWrapper>;
+  return <LeftButton onClick={handleOnClick}>{children}</LeftButton>;
 };
 
-const ModalWrapper = styled.section`
-  display: flex;
+const ModalWrapper = styled.section<{ $isVisible: boolean }>`
+  display: ${({ $isVisible }) => ($isVisible ? 'flex' : 'none')};
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -95,7 +112,7 @@ const ModalBtnLayout = styled.div`
   gap: 1.2rem;
 `;
 
-const RightBtnWrapper = styled.button`
+const RightButton = styled.button`
   width: 15.4rem;
   height: 3.9rem;
   padding: 1rem 0;
@@ -114,7 +131,7 @@ const RightBtnWrapper = styled.button`
   }
 `;
 
-const LeftBtnWrapper = styled.button`
+const LeftButton = styled.button`
   width: 15.4rem;
   height: 3.9rem;
   padding: 1rem 0;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -5,13 +5,13 @@ import Spacing from './Spacing';
 
 interface ModalContentPropTypes {
   modalContent: string;
-  positiveBtnHandler: () => void;
+  onClick: () => void;
   setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // '아니오'를 유도하는 모달
 export const NegativeModal = (props: ModalContentPropTypes) => {
-  const { modalContent, positiveBtnHandler } = props;
+  const { modalContent, onClick } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const negativeBtnHandler = () => {
     setIsVisible(false);
@@ -22,7 +22,7 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <NegativeButton onClick={positiveBtnHandler}>예</NegativeButton>
+        <NegativeButton onClick={onClick}>예</NegativeButton>
         <PositiveButton onClick={negativeBtnHandler}>아니오</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>
@@ -31,7 +31,7 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
 
 // '예'를 유도하는 모달
 export const PositiveModal = (props: ModalContentPropTypes) => {
-  const { modalContent, positiveBtnHandler } = props;
+  const { modalContent, onClick } = props;
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const negativeBtnHandler = () => {
     setIsVisible(false);
@@ -44,7 +44,7 @@ export const PositiveModal = (props: ModalContentPropTypes) => {
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
         <NegativeButton onClick={negativeBtnHandler}>아니오</NegativeButton>
-        <PositiveButton onClick={positiveBtnHandler}>예</PositiveButton>
+        <PositiveButton onClick={onClick}>예</PositiveButton>
       </ModalBtnLayout>
     </ModalWrapper>
   );

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -11,7 +11,6 @@ interface modalContentPropTypes {
 
 interface ButtonPropTypes {
   children: string;
-  isRightButton: boolean; // 버튼이 오른쪽에 있는지 여부
   confirmRoutingTo?: string | undefined; // '예' 버튼이 라우팅 되는 곳을 나타냄
   // cancelRoutingTo?: string | undefined; // '아니오' 버튼이 라우팅 되는 곳을 나타냄
 }
@@ -25,10 +24,8 @@ export const NegativeModal = (props: modalContentPropTypes) => {
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton confirmRoutingTo={confirmRoutingTo} isRightButton={false}>
-          예
-        </ModalButton>
-        <ModalButton isRightButton={true}>아니오</ModalButton>
+        <LeftBtn confirmRoutingTo={confirmRoutingTo}>예</LeftBtn>
+        <RightBtn>아니오</RightBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
@@ -43,17 +40,15 @@ export const PositiveModal = (props: modalContentPropTypes) => {
       <ModalContentLayout>{modalContent}</ModalContentLayout>
       <Spacing marginBottom="3.2" />
       <ModalBtnLayout>
-        <ModalButton isRightButton={false}>아니오</ModalButton>
-        <ModalButton confirmRoutingTo={confirmRoutingTo} isRightButton={true}>
-          예
-        </ModalButton>
+        <LeftBtn>아니오</LeftBtn>
+        <RightBtn confirmRoutingTo={confirmRoutingTo}>예</RightBtn>
       </ModalBtnLayout>
     </ModalWrapper>
   );
 };
 
-export const ModalButton = (props: ButtonPropTypes) => {
-  const { confirmRoutingTo, children, isRightButton } = props;
+export const RightBtn = (props: ButtonPropTypes) => {
+  const { confirmRoutingTo, children } = props;
   const navigate = useNavigate();
   const handleOnClick = () => {
     if (confirmRoutingTo) {
@@ -61,11 +56,19 @@ export const ModalButton = (props: ButtonPropTypes) => {
     }
   };
 
-  return (
-    <ModalBtnWrapper onClick={handleOnClick} $isRightButton={isRightButton}>
-      {children}
-    </ModalBtnWrapper>
-  );
+  return <RightBtnWrapper onClick={handleOnClick}>{children}</RightBtnWrapper>;
+};
+
+export const LeftBtn = (props: ButtonPropTypes) => {
+  const { confirmRoutingTo, children } = props;
+  const navigate = useNavigate();
+  const handleOnClick = () => {
+    if (confirmRoutingTo) {
+      navigate(`${confirmRoutingTo}`);
+    }
+  };
+
+  return <LeftBtnWrapper onClick={handleOnClick}>{children}</LeftBtnWrapper>;
 };
 
 const ModalWrapper = styled.section`
@@ -94,19 +97,34 @@ const ModalBtnLayout = styled.div`
   gap: 1.2rem;
 `;
 
-const ModalBtnWrapper = styled.button<{ $isRightButton: boolean }>`
+const RightBtnWrapper = styled.button`
   width: 15.4rem;
   height: 3.9rem;
   padding: 1rem 0;
 
-  color: ${({ $isRightButton, theme }) =>
-    $isRightButton ? theme.colors.white : theme.colors.mainViolet};
+  color: ${({ theme }) => theme.colors.white};
 
-  background-color: ${({ $isRightButton, theme }) =>
-    $isRightButton ? theme.colors.mainViolet : theme.colors.white};
-  border: 1px solid
-    ${({ $isRightButton, theme }) =>
-      $isRightButton ? theme.colors.mileViolet : theme.colors.mainViolet};
+  background-color: ${({ theme }) => theme.colors.mainViolet};
+  border-radius: 0.8rem;
+
+  ${({ theme }) => theme.fonts.button2};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.mainViolet};
+
+    background-color: ${({ theme }) => theme.colors.mileViolet};
+  }
+`;
+
+const LeftBtnWrapper = styled.button`
+  width: 15.4rem;
+  height: 3.9rem;
+  padding: 1rem 0;
+
+  color: ${({ theme }) => theme.colors.mainViolet};
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.mainViolet};
   border-radius: 0.8rem;
 
   ${({ theme }) => theme.fonts.button2};


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #262 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] [유형 1] 에디터 페이지 나가기 모달, 관리자 멤버관리- 멤버 추방 모달 제작
- [x] [유형 2] 글모임 초대- 필명변경모달, 글모임 생성 - 필명 변경 불가 확인 모달 제작

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
### 💅🏻 props로 문자열을 전달해줄 때 줄바꿈 처리하는 방법
<img width="300" alt="스크린샷 2024-03-17 오후 8 10 45" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/bf173f33-ea5d-4f6d-a860-c125cf995b1c">

- Modal 컴포넌트에서 modalContent={`가입 완료 시 필명 변경이 불가합니다. \n계속 하시겠습니까?`}와 같이 props를 전달해줬으나 위와 같이 줄바꿈 처리가 적용되지 않았습니다.

**해결**
```
white-space: pre-line;
```
- 모달의 내용이 있는 스타일 컴포넌트에서 위의 속성을 추가해주어 해결할 수 있었습니다. 위 속성을 추가해주고 `<br>`혹은 `\n`을 사용해서 줄바꿈 처리를 해주면 됩니다.
- `pre-line` 속성값은 줄바꿈 문자만 있는 그대로 처리하고 연속되는 띄어쓰기와 들여쓰기는 모두 띄어쓰기 한 번으로 처리하는 속성입니다.

<br />

---

### 👋🏻 컴포넌트 설명
두 가지 모달이 색이 칠해져 있는 버튼이 달랐는데, 색이 칠해져있는 버튼에 초점을 두어 해당 버튼이 사용자가 누르도록 유도하는 버튼이라고 판단했습니다. 그래서 컴포넌트명도 `NegativeModal`, `PositiveModal`로 정했습니다.
- `아니오` 버튼에 색이 칠해져 있는 컴포넌트가 `NegativeModal`과 `예`를 유도하는 `PositiveModal`로 나누어 제작했습니다. 그리고 모달의 버튼을 `ModalButton`이라는 컴포넌트로 나눴습니다.

`NegativeModal`, `PositiveModal`의 props들은 다음과 같습니다.

```tsx
interface modalContentPropTypes {
  modalContent: string;
  onClick: () => void; // `예` 버튼을 눌렀을 때 동작하는 함수
  setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>; // `아니오` 버튼을 눌렀을 때 창이 닫히도록 상태관리
}
```

<br />


```tsx
// '아니오'를 유도하는 모달
export const NegativeModal = (props: ModalContentPropTypes) => {
  const { modalContent, onClick } = props;
  const [isVisible, setIsVisible] = useState<boolean>(true);
  const negativeBtnHandler = () => {
    setIsVisible(false);
  };

  return (
    <ModalWrapper $isVisible={isVisible}>
      <ModalContentLayout>{modalContent}</ModalContentLayout>
      <Spacing marginBottom="3.2" />
      <ModalBtnLayout>
        <NegativeButton onClick={onClick}>예</NegativeButton>
        <PositiveButton onClick={negativeBtnHandler}>아니오</PositiveButton>
      </ModalBtnLayout>
    </ModalWrapper>
  );
};
```
- 모달 컴포넌트의 버튼에 핸들러를 부여해서`아니오` 버튼의 경우는 모달이 닫히고, `예` 버튼의 경우 해당 페이지에서 전달해주는 onClick 함수에 따라 동작하도록 코드를 작성해주었습니다.

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

`/` 에서 테스트


https://github.com/Mile-Writings/Mile-Client/assets/96781926/d6b883c0-38ab-4a06-97a3-b5e457fa2535


https://github.com/Mile-Writings/Mile-Client/assets/96781926/4cbdf95e-6a7c-423e-b00d-4b60a783adda





