### PR TITLE
[Fix/#278] 공통 모달 버그 수정

### DIFF
--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -107,9 +107,9 @@ const ModalWrapper = styled.section<{ $isModalOpen: boolean }>`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 40rem;
-  height: 18.1rem;
-  padding: 3.2rem;
+  width: auto;
+  height: auto;
+  padding: 3.2rem 4rem;
 
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 1rem;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Spacing from './Spacing';
 
@@ -27,6 +27,12 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
       setModalBgClickActive(false);
     }
   };
+  /* 모달이 닫힐 때마다 배경 클릭 여부도 함께 초기화 */
+  useEffect(() => {
+    if (!isModalOpen) {
+      setModalBgClickActive(false);
+    }
+  }, [isModalOpen]);
   useClickOutside(modalRef, handleOutSideClick);
 
   return (
@@ -58,6 +64,13 @@ export const PositiveModal = (props: ModalContentPropTypes) => {
       setModalBgClickActive(false);
     }
   };
+  /* 모달이 닫힐 때마다 배경 클릭 여부도 함께 초기화 */
+  useEffect(() => {
+    if (!isModalOpen) {
+      setModalBgClickActive(false);
+    }
+  }, [isModalOpen]);
+
   useClickOutside(modalRef, handleOutSideClick);
 
   return (

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
+import { useRef, useState } from 'react';
 
 import Spacing from './Spacing';
+
+import useClickOutside from '../../hooks/useClickOutside';
 
 interface ModalContentPropTypes {
   modalContent: string;
@@ -12,10 +15,23 @@ interface ModalContentPropTypes {
 // '아니오'를 유도하는 모달
 export const NegativeModal = (props: ModalContentPropTypes) => {
   const { modalContent, modalHandler, closeModalHandler, isModalOpen } = props;
+  const [modalBgClickActive, setModalBgClickActive] = useState(isModalOpen);
+  const modalRef = useRef(null);
+
+  const handleOutSideClick = () => {
+    if (isModalOpen) {
+      setModalBgClickActive(true);
+    }
+    if (modalBgClickActive) {
+      closeModalHandler();
+      setModalBgClickActive(false);
+    }
+  };
+  useClickOutside(modalRef, handleOutSideClick);
 
   return (
     <ModalBackgroundWrapper $isModalOpen={isModalOpen}>
-      <ModalWrapper $isModalOpen={isModalOpen}>
+      <ModalWrapper ref={modalRef} $isModalOpen={isModalOpen}>
         <ModalContentLayout>{modalContent}</ModalContentLayout>
         <Spacing marginBottom="3.2" />
         <ModalBtnLayout>
@@ -30,10 +46,23 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
 // '예'를 유도하는 모달
 export const PositiveModal = (props: ModalContentPropTypes) => {
   const { modalContent, modalHandler, closeModalHandler, isModalOpen } = props;
+  const [modalBgClickActive, setModalBgClickActive] = useState(isModalOpen);
+  const modalRef = useRef(null);
+
+  const handleOutSideClick = () => {
+    if (isModalOpen) {
+      setModalBgClickActive(true);
+    }
+    if (modalBgClickActive) {
+      closeModalHandler();
+      setModalBgClickActive(false);
+    }
+  };
+  useClickOutside(modalRef, handleOutSideClick);
 
   return (
     <ModalBackgroundWrapper $isModalOpen={isModalOpen}>
-      <ModalWrapper $isModalOpen={isModalOpen}>
+      <ModalWrapper ref={modalRef} $isModalOpen={isModalOpen}>
         <ModalContentLayout>{modalContent}</ModalContentLayout>
         <Spacing marginBottom="3.2" />
         <ModalBtnLayout>

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -1,64 +1,65 @@
 import styled from '@emotion/styled';
-import React, { useRef, useState } from 'react';
 
 import Spacing from './Spacing';
 
-import useClickOutside from '../../hooks/useClickOutside';
-
 interface ModalContentPropTypes {
   modalContent: string;
-  onClick: () => void;
-  setIsVisible?: React.Dispatch<React.SetStateAction<boolean>>;
+  isModalOpen: boolean;
+  modalHandler: () => void;
+  closeModalHandler: () => void;
 }
 
 // '아니오'를 유도하는 모달
 export const NegativeModal = (props: ModalContentPropTypes) => {
-  const { modalContent, onClick } = props;
-  const [isVisible, setIsVisible] = useState<boolean>(true);
-  const modalRef = useRef(null);
-  const closeModalHandler = () => {
-    setIsVisible(false);
-  };
-  useClickOutside(modalRef, closeModalHandler);
+  const { modalContent, modalHandler, closeModalHandler, isModalOpen } = props;
 
   return (
-    <ModalWrapper ref={modalRef} $isVisible={isVisible}>
-      <ModalContentLayout>{modalContent}</ModalContentLayout>
-      <Spacing marginBottom="3.2" />
-      <ModalBtnLayout>
-        <NegativeButton onClick={onClick}>예</NegativeButton>
-        <PositiveButton onClick={closeModalHandler}>아니오</PositiveButton>
-      </ModalBtnLayout>
-    </ModalWrapper>
+    <ModalBackgroundWrapper $isModalOpen={isModalOpen}>
+      <ModalWrapper $isModalOpen={isModalOpen}>
+        <ModalContentLayout>{modalContent}</ModalContentLayout>
+        <Spacing marginBottom="3.2" />
+        <ModalBtnLayout>
+          <NegativeButton onClick={modalHandler}>예</NegativeButton>
+          <PositiveButton onClick={closeModalHandler}>아니오</PositiveButton>
+        </ModalBtnLayout>
+      </ModalWrapper>
+    </ModalBackgroundWrapper>
   );
 };
 
 // '예'를 유도하는 모달
 export const PositiveModal = (props: ModalContentPropTypes) => {
-  const { modalContent, onClick } = props;
-  const [isVisible, setIsVisible] = useState<boolean>(true);
-  const modalRef = useRef(null);
-
-  const closeModalHandler = () => {
-    setIsVisible(false);
-  };
-
-  useClickOutside(modalRef, closeModalHandler);
+  const { modalContent, modalHandler, closeModalHandler, isModalOpen } = props;
 
   return (
-    <ModalWrapper ref={modalRef} $isVisible={isVisible}>
-      <ModalContentLayout>{modalContent}</ModalContentLayout>
-      <Spacing marginBottom="3.2" />
-      <ModalBtnLayout>
-        <NegativeButton onClick={closeModalHandler}>아니오</NegativeButton>
-        <PositiveButton onClick={onClick}>예</PositiveButton>
-      </ModalBtnLayout>
-    </ModalWrapper>
+    <ModalBackgroundWrapper $isModalOpen={isModalOpen}>
+      <ModalWrapper $isModalOpen={isModalOpen}>
+        <ModalContentLayout>{modalContent}</ModalContentLayout>
+        <Spacing marginBottom="3.2" />
+        <ModalBtnLayout>
+          <NegativeButton onClick={closeModalHandler}>아니오</NegativeButton>
+          <PositiveButton onClick={modalHandler}>예</PositiveButton>
+        </ModalBtnLayout>
+      </ModalWrapper>
+    </ModalBackgroundWrapper>
   );
 };
 
-const ModalWrapper = styled.section<{ $isVisible: boolean }>`
-  display: ${({ $isVisible }) => ($isVisible ? 'flex' : 'none')};
+const ModalBackgroundWrapper = styled.div<{ $isModalOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  z-index: 1;
+  display: ${({ $isModalOpen }) => ($isModalOpen ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+
+  background-color: rgb(0 0 0 / 60%);
+`;
+
+const ModalWrapper = styled.section<{ $isModalOpen: boolean }>`
+  display: ${({ $isModalOpen }) => ($isModalOpen ? 'flex' : 'none')};
   flex-direction: column;
   align-items: center;
   justify-content: center;

--- a/src/components/commons/Modal.tsx
+++ b/src/components/commons/Modal.tsx
@@ -35,12 +35,6 @@ export const NegativeModal = (props: ModalContentPropTypes) => {
     }
   }, [isModalOpen]);
 
-  /* 모달이 닫힐 때마다 배경 클릭 여부도 함께 초기화 */
-  useEffect(() => {
-    if (!isModalOpen) {
-      setModalBgClickActive(false);
-    }
-  }, [isModalOpen]);
   useClickOutside(modalRef, handleOutSideClick);
 
   return (

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -3,11 +3,9 @@ import { useState } from 'react';
 const useModal = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const showModal = () => {
-    console.log(isModalOpen);
     setIsModalOpen(true);
   };
   const closeModal = () => {
-    console.log(isModalOpen);
     setIsModalOpen(false);
   };
   return {

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -3,13 +3,16 @@ import { useState } from 'react';
 const useModal = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const showModal = () => {
+    console.log(isModalOpen);
     setIsModalOpen(true);
   };
   const closeModal = () => {
+    console.log(isModalOpen);
     setIsModalOpen(false);
   };
   return {
     isModalOpen,
+    setIsModalOpen,
     showModal,
     closeModal,
   };

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -2,17 +2,16 @@ import { useState } from 'react';
 
 const useModal = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const showModal = () => {
+  const handleShowModal = () => {
     setIsModalOpen(true);
   };
-  const closeModal = () => {
+  const handleCloseModal = () => {
     setIsModalOpen(false);
   };
   return {
     isModalOpen,
-    setIsModalOpen,
-    showModal,
-    closeModal,
+    handleShowModal,
+    handleCloseModal,
   };
 };
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const showModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+  return {
+    isModalOpen,
+    showModal,
+    closeModal,
+  };
+};
+
+export default useModal;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #278 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 뒤의 검정 배경까지 같이 common으로 빼고 중앙정렬
- [x] ref 영역 다시 잡기
- [x] 처음 모달 열리는 state를 prop에 추가
- [ ] 스크롤 방지 함수 연결

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
### 🫧 useModal 커스텀 훅
모달의 상태를 관리하면서 **모달을 열고 닫는** 상태 관리 코드가 중복되는 걸 발견해서 이를 커스텀 훅으로 분리해서 관리했습니다.
```tsx
const useModal = () => {
  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
  const handleShowModal = () => {
    setIsModalOpen(true);
  };
  const handleCloseModal = () => {
    setIsModalOpen(false);
  };
  return {
    isModalOpen,
    setIsModalOpen,
    handleShowModal,
    handleCloseModal,
  };
};
```

---

<br />

### 🫧 모달 테스트 

테스트를 위해 로그인 페이지에서 로그인 버튼을 누를 때 모달이 뜨게 했고, 아니오 -> 원래 페이지, 예 -> 메인 페이지로 핸들링 되는 PositiveModal을 불러온 모습입니다. 
(아직 스크롤 방지 함수를 적용하지 않은 상태입니다!)

https://github.com/Mile-Writings/Mile-Client/assets/96781926/8b0e43b2-abc4-417c-b72e-3c248ba8deca

- 로그인 페이지에서는 다음 코드와 같이 useModal로부터 핸들러 함수와 모달의 현재 상태를 가져오고, 핸들러가 필요한 부분에 onClick을 적용하여 모달을 띄울 수 있습니다. 
- Modal 컴포넌트가 받는 인자 중 modalHandler에 '예' 버튼을 눌렀을 때 어떤 함수를 실행할지 전달해주면 되며, closeModalHandler에는 useModal에서 받아온 handleCloseModal 함수를 넘겨주면 됩니다!
> isModalOpen : 모달의 현재 상태 (열림 true / 닫힘 false)
handleCloseModal : 모달을 닫는 핸들러
handleShowModal : 모달을 여는 핸들러

```tsx
  const { isModalOpen, handleCloseModal, handleShowModal } = useModal();

  return (
    <LoginWrapper>
      <PositiveModal
        modalContent={`가입 완료 시 필명 변경이 불가합니다.\n계속 하시겠습니까?`}
        isModalOpen={isModalOpen}
        modalHandler={handleNavigateMain}
        closeModalHandler={handleCloseModal}
      />
      // ... 생략
          <KakaoLoginBtnIcon onClick={handleShowModal} />
      // ... 생략
    </LoginWrapper>
  );
```

---

<br />

### 💥 트러블 슈팅 - 두 번 눌러야 모달이 띄워짐

https://github.com/Mile-Writings/Mile-Client/assets/96781926/279eb7d8-4af4-4a8b-a660-91235984c6c4

위 영상과 같이 '아니오'버튼의 경우 누른 뒤 모달을 띄우는 버튼을 두 번 눌러야 모달이 띄워지는 문제가 있었습니다.
- 콘솔로 확인해보니 '아니오' 버튼을 누른 다음 곧바로 모달을 띄우는 버튼을 클릭하게 되면 이를 모달의 뒷 배경이라고 간주해서 뒷 배경의 클릭 여부에 대한 상태(`setModalBgClickActive`)가 true가 되어 모달이 한 번에 띄워지지 않기 때문이라는 걸 발견했습니다.
그래서 useEffect를 사용해서 모달의 상태가 바뀔 때마다 닫혀있는 상태라면 뒷 배경 클릭 여부도 false로 재설정해주는 코드를 추가해줬습니다.
```tsx
  useEffect(() => {
    if (!isModalOpen) {
      setModalBgClickActive(false);
    }
  }, [isModalOpen]);
```

<br />

### 💥 트러블 슈팅 - 모달의 배경 영역 잡기
사진에 보이는 것처럼 모달 뒷 배경의 영역이 애매하게 치우친 걸 확인할 수 있었습니다

<img width="1031" alt="스크린샷 2024-04-09 오전 2 56 15" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/ede10965-021c-4208-acd0-74b2b396fcf9">

이건 제가 HeaderWrapper 안에 모달을 위치시킨 게 원인이었습니다. 
사용하실 때 저처럼 실수 하지 말구 가장 최상단 wrapper 에 모달을 불러와주세요...!!ㅎㅎ🥹

```tsx
    <LoginWrapper>
      <HeaderWrapper>
        <NegativeModal
          modalContent="테스트"
          isModalOpen={isModalOpen}
          modalHandler={handleNavigateMain}
          closeModalHandler={handleCloseModal}
        />
        <HeaderLogoIcon onClick={handleNavigateMain} />
        <HeaderBtnLayout />
      </HeaderWrapper>
// 생략
```


## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

**[글 모임 생성 페이지]**

<img width="1031" alt="스크린샷 2024-04-09 오전 3 05 36" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/e83ca665-c5ae-4aee-bb9e-83d73bed2caa">

**[에디터 페이지]**

<img width="1032" alt="스크린샷 2024-04-09 오전 3 07 25" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/1ab59f47-1331-4471-b9a2-2bb1210e0309">

<img width="1031" alt="스크린샷 2024-04-09 오전 3 08 19" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/bad7f74f-66fd-45a6-a59b-68e0bfbeae83">


**[글감 관리 페이지]**

<img width="1029" alt="스크린샷 2024-04-09 오전 3 18 20" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/618815a7-ec68-482b-8edc-3a37127c588a">

**[멤버 관리 페이지]**

<img width="1032" alt="스크린샷 2024-04-09 오전 3 23 45" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/e54739c9-7780-4452-93db-5b6d0bd6baef">

