### PR TITLE
[Fix/#308] 멤버 삭제 모달 띄우기

### DIFF
--- a/src/pages/admin/apis/fetchDeleteMember.ts
+++ b/src/pages/admin/apis/fetchDeleteMember.ts
@@ -14,7 +14,7 @@ interface MembersListTypes {
 const fetchDeleteMember = async (writerNameId: number | undefined) => {
   try {
     const token = localStorage.getItem('accessToken');
-    const data = await devClient.delete<MembersListTypes>(`/api/writerName/${writerNameId}`, {
+    const data = await devClient.delete<MembersListTypes>(`/api/writername/${writerNameId}`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/pages/admin/components/MemberManage.tsx
+++ b/src/pages/admin/components/MemberManage.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useDeleteMember, useFetchMemberInfo } from '../hooks/queries';
 
 import { adminEmptyMemberIc as AdminEmptyMemberIcon, adminProfileIc } from '../../../assets/svgs';
+import { NegativeModal } from '../../../components/commons/Modal';
 import Pagenation from '../../../components/commons/Pagenation';
 import Spacing from '../../../components/commons/Spacing';
+import useModal from '../../../hooks/useModal';
 
 export interface MemberPropTypes {
   pageNumber: number;
@@ -29,10 +31,12 @@ const MemberManage = ({ data, setPageCount, pageCount }: MemberManagePropTypes) 
   const { groupId } = useParams();
   const { memberData } = useFetchMemberInfo(groupId || '', pageCount);
   const { deleteMember } = useDeleteMember();
+  const { isModalOpen, handleShowModal, handleCloseModal } = useModal();
+  const [deleteMemberId, setDeleteMemberId] = useState(-1);
 
   return (
     <>
-      <MemberListWrapper>
+      <MemberTableWrapper>
         <TableHeaderLayout>
           <Header>프로필</Header>
           <Header>필명</Header>
@@ -48,7 +52,14 @@ const MemberManage = ({ data, setPageCount, pageCount }: MemberManagePropTypes) 
                 <Name>{writerName}</Name>
                 <PostNumber>{postCount}</PostNumber>
                 <CommentNumber>{commentCount}</CommentNumber>
-                <ExpelBtn onClick={() => deleteMember(writerNameId)}>삭제하기</ExpelBtn>
+                <ExpelBtn
+                  onClick={() => {
+                    setDeleteMemberId(writerNameId);
+                    handleShowModal();
+                  }}
+                >
+                  삭제하기
+                </ExpelBtn>
               </MemberItemContainer>
             ))
           ) : (
@@ -59,7 +70,7 @@ const MemberManage = ({ data, setPageCount, pageCount }: MemberManagePropTypes) 
             </EmptyContainer>
           )}
         </MemberLayout>
-      </MemberListWrapper>
+      </MemberTableWrapper>
       <Spacing marginBottom="3.6" />
       {memberData && memberData.writerNameCount && (
         <Pagenation
@@ -69,13 +80,27 @@ const MemberManage = ({ data, setPageCount, pageCount }: MemberManagePropTypes) 
           activePage={pageCount}
         />
       )}
+      <NegativeModal
+        modalContent={
+          '삭제 시, 해당 멤버와 해당 멤버가 작성한\n글과 댓글도 모두 삭제됩니다. 계속 하시겠습니까?'
+        }
+        isModalOpen={isModalOpen}
+        modalHandler={() => {
+          deleteMember(deleteMemberId);
+          handleCloseModal();
+        }}
+        closeModalHandler={() => {
+          setDeleteMemberId(-1);
+          handleCloseModal();
+        }}
+      />
     </>
   );
 };
 
 export default MemberManage;
 
-const MemberListWrapper = styled.section`
+const MemberTableWrapper = styled.section`
   display: flex;
   flex-direction: column;
   width: 78.1rem;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #308 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 멤버 삭제 시 모달 띄우기

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
### 삭제하는 멤버 id 전달
```tsx
const [deleteMemberId, setDeleteMemberId] = useState(-1);
... 생략
                <ExpelBtn
                  onClick={() => {
                    setDeleteMemberId(writerNameId);
                    handleShowModal();
                  }}
... 생략
      <NegativeModal
        modalContent={
          '삭제 시, 해당 멤버와 해당 멤버가 작성한\n글과 댓글도 모두 삭제됩니다. 계속 하시겠습니까?'
        }
        isModalOpen={isModalOpen}
        modalHandler={() => {
          deleteMember(deleteMemberId);
          handleCloseModal();
        }}
        closeModalHandler={() => {
          setDeleteMemberId(-1);
          handleCloseModal();
        }}
      />
```
- useState를 사용해서 삭제하기 버튼이 눌렸을 때 삭제될 멤버의 id를 저장해주고, 모달에서 인자로 전달해주어 저장된 멤버 id에 해당하는 멤버를 삭제해주었습니다.

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

https://github.com/Mile-Writings/Mile-Client/assets/96781926/8e554d9f-7b17-4260-ab33-4a1567e5142a


