### PR TITLE
[Style/#334] 헤더 글 모임 없을 때 정렬 수정

### DIFF
--- a/src/pages/groupFeed/components/MyGroupDropDown.tsx
+++ b/src/pages/groupFeed/components/MyGroupDropDown.tsx
@@ -114,15 +114,15 @@ const GroupContentContainer = styled.div<{ $isEmpty: boolean }>`
   white-space: pre-line;
   text-align: ${({ $isEmpty }) => ($isEmpty ? 'center' : 'left')};
 
-  cursor: pointer;
+  cursor: ${({ $isEmpty }) => ($isEmpty ? 'auto' : 'cursor')};
   border-radius: 0.8rem;
-  ${({ theme }) => theme.fonts.body1};
+  ${({ $isEmpty, theme }) => ($isEmpty ? theme.fonts.body9 : theme.fonts.body1)};
 
   &:hover {
-    color: ${({ theme }) => theme.colors.black};
+    color: ${({ $isEmpty, theme }) => !$isEmpty && theme.colors.black};
 
-    background-color: ${({ theme }) => theme.colors.gray10};
+    background-color: ${({ $isEmpty, theme }) => !$isEmpty && theme.colors.gray10};
 
-    ${({ theme }) => theme.fonts.subtitle6};
+    ${({ $isEmpty, theme }) => !$isEmpty && theme.fonts.subtitle6};
   }
 `;

--- a/src/pages/groupFeed/components/MyGroupDropDown.tsx
+++ b/src/pages/groupFeed/components/MyGroupDropDown.tsx
@@ -106,7 +106,6 @@ const MyGroupListLayout = styled.div<{ $isOpen: boolean }>`
 `;
 
 const GroupContentContainer = styled.div<{ $isEmpty: boolean }>`
-  display: flex;
   width: 15.2rem;
   padding: 1rem 1.6rem;
 

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -65,6 +65,7 @@ declare module '@emotion/react' {
       body6: SerializedStyles;
       body7: SerializedStyles;
       body8: SerializedStyles;
+      body9: SerializedStyles;
       button1: SerializedStyles;
       button2: SerializedStyles;
       button3: SerializedStyles;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -238,6 +238,13 @@ export const theme = {
       font-style: normal;
       line-height: 200%; /* 24px */
     `,
+    body9: css`
+      font-weight: 500;
+      font-size: 1.6rem;
+      font-family: 'Pretendard Variable', sans-serif;
+      font-style: normal;
+      line-height: 150%; /* 24px */
+    `,
     button1: css`
       font-weight: 600;
       font-size: 1.6rem;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #334

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 헤더 글 모임 없을 때 정렬 수정
- [x] 글 모임 없을 때 `cursor: pointer;` 없애기

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- display flex 속성 때문에 살짝 시작 부분으로 정렬이 맞춰져 있더라고요..! 
- props로 그룹이 없는 지에 대한 여부를 isEmpty로 받아서 그 값에 따라 스타일 지정해줬습니다.

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-


## 📌스크린샷(선택)

<img width="214" alt="스크린샷 2024-06-03 오전 1 59 11" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/d05bc3dc-bf6d-4a3f-b2e9-4355f86cbc7d">