### PR TITLE
[Fix/#338] 초대 링크 변경

### DIFF
--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -15,7 +15,7 @@ const Admin = () => {
   const { groupId } = useParams();
   const { invitationCode } = useFetchInvitationLink(groupId);
 
-  const handleCopyLink = async (invitationCode: string) => {
+  const handleCopyLink = (invitationCode: string) => {
     copyLink(`https://www.milewriting.com/group/${invitationCode}/groupInvite`);
   };
 

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -7,6 +7,7 @@ import RenderAdminContent from './RenderAdminContent';
 
 import { AuthorizationHeader, UnAuthorizationHeader } from '../../components/commons/Header';
 import Spacing from '../../components/commons/Spacing';
+import { copyLink } from '../../utils/copyLink';
 
 const Admin = () => {
   const accessToken = localStorage.getItem('accessToken');
@@ -15,14 +16,7 @@ const Admin = () => {
   const { invitationCode } = useFetchInvitationLink(groupId);
 
   const handleCopyLink = async (invitationCode: string) => {
-    try {
-      await navigator.clipboard.writeText(
-        `https://www.milewriting.com/group/${invitationCode}/groupInvite`,
-      );
-      alert('초대링크가 복사되었습니다.');
-    } catch {
-      console.error();
-    }
+    copyLink(`https://www.milewriting.com/group/${invitationCode}/groupInvite`);
   };
 
   return (

--- a/src/pages/createGroupSuccess/CreateGroupSuccess.tsx
+++ b/src/pages/createGroupSuccess/CreateGroupSuccess.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { CreateGroupCongrats } from '../../assets/svgs';
 import { AuthorizationHeader, UnAuthorizationHeader } from '../../components/commons/Header';
+import { copyLink } from '../../utils/copyLink';
 
 const CreateGroupSuccess = () => {
   const token = localStorage.getItem('accessToken');
@@ -11,13 +12,7 @@ const CreateGroupSuccess = () => {
   const navigate = useNavigate();
 
   const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(`https://www.milewriting.com/${groupId}/groupInvite`);
-      alert('초대 링크가 복사되었습니다.');
-    } catch (err) {
-      console.error('클립보드 복사 실패:', err);
-      alert('클립보드 복사 실패');
-    }
+    copyLink(`https://www.milewriting.com/${groupId}/groupInvite`);
   };
 
   return (

--- a/src/pages/createGroupSuccess/CreateGroupSuccess.tsx
+++ b/src/pages/createGroupSuccess/CreateGroupSuccess.tsx
@@ -12,7 +12,7 @@ const CreateGroupSuccess = () => {
 
   const handleCopyLink = async () => {
     try {
-      await navigator.clipboard.writeText(`http://localhost:5173/group/${groupId}/groupInvite`);
+      await navigator.clipboard.writeText(`https://www.milewriting.com/${groupId}/groupInvite`);
       alert('초대 링크가 복사되었습니다.');
     } catch (err) {
       console.error('클립보드 복사 실패:', err);

--- a/src/utils/copyLink.ts
+++ b/src/utils/copyLink.ts
@@ -1,0 +1,9 @@
+export const copyLink = async (link: string) => {
+  try {
+    await navigator.clipboard.writeText(link);
+    alert('초대 링크가 복사되었습니다.');
+  } catch (err) {
+    console.error('클립보드 복사 실패:', err);
+    alert('클립보드 복사 실패');
+  }
+};


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #338

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 배포링크 주소로 초대 링크 변경
- [x] 초대링크 복사 로직 유틸 함수로 분리

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
```tsx
export const copyLink = async (link: string) => {
  try {
    await navigator.clipboard.writeText(link);
    alert('초대 링크가 복사되었습니다.');
  } catch (err) {
    console.error('클립보드 복사 실패:', err);
    alert('클립보드 복사 실패');
  }
};
```
- 다음과 같이 초대링크를 복사하는 로직을 `copyLink`함수로 빼줬습니다.

```tsx
  const handleCopyLink = (invitationCode: string) => {
    copyLink(`https://www.milewriting.com/group/${invitationCode}/groupInvite`);
  };
```
- 위와 같이 핸들러 함수를 통해 유틸 함수를 불러와서 사용해줬습니다. 
- 유틸 함수 인자로 복사할 링크 전달해줬습니다.

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
