### PR TITLE
[fix/#336] 캐러셀 새로고침 방지

### DIFF
--- a/src/pages/groupFeed/carousel/Carousel.tsx
+++ b/src/pages/groupFeed/carousel/Carousel.tsx
@@ -56,10 +56,6 @@ const Carousel = () => {
 
   const { topicInfo, isLoading: articleListLoading } = useArticleList(selectedTopicId || '');
 
-  if (isLoading || articleListLoading) {
-    return <Loading />;
-  }
-
   if (isError) {
     console.log(error?.message, 'error');
     return <Error />;
@@ -67,6 +63,7 @@ const Carousel = () => {
 
   return (
     <>
+      {(articleListLoading || isLoading) && <Loading />}
       <CarouselWrapper>
         {groupFeedCategoryData != undefined && groupFeedCategoryData?.length > 6 && (
           <GroupTabBtnBaseBeforeIcon />


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #336 


### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->


## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 기존 코드에서

https://github.com/Mile-Writings/Mile-Client/assets/93575538/a24bb027-b3d3-401a-8367-ee797200716f


이렇게 캐러셀이 맨 첫번쨰 슬라이드로 넘어오는 문제가 있었는데, Loading때문이었어요..
그게 실행될 동안 기존의 컴포넌트 트리가 언마운트되면서 로딩 후 다시 렌더링하려하면 초기상태로 돌아가는거죠

컴포넌트 전체를 언마운트 시키지 않는 방식으로 바꿨습니당~


## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
