### PR TITLE
[Feat] 글 모임 장인 경우 멤버 삭제 불가

### DIFF
--- a/src/pages/admin/apis/fetchMemberInfo.ts
+++ b/src/pages/admin/apis/fetchMemberInfo.ts
@@ -19,6 +19,7 @@ export interface FetchMemberPropTypes {
       writerName: string;
       postCount: number;
       commentCount: number;
+      isOwner: boolean;
     }[];
   };
 }

--- a/src/pages/admin/components/MemberManage.tsx
+++ b/src/pages/admin/components/MemberManage.tsx
@@ -201,6 +201,7 @@ const CommentNumber = styled.pre`
 
 const ExpelBtn = styled.button`
   margin-left: auto;
+  padding: 0;
 
   color: ${({ theme }) => theme.colors.gray50};
   ${({ theme }) => theme.fonts.body5};

--- a/src/pages/admin/components/MemberManage.tsx
+++ b/src/pages/admin/components/MemberManage.tsx
@@ -10,7 +10,7 @@ import Pagenation from '../../../components/commons/Pagenation';
 import Spacing from '../../../components/commons/Spacing';
 import useModal from '../../../hooks/useModal';
 
-export interface MemberPropTypes {
+interface MemberPropTypes {
   pageNumber: number;
   writerNameCount: number;
   writerNameList: {
@@ -18,6 +18,7 @@ export interface MemberPropTypes {
     writerName: string;
     postCount: number;
     commentCount: number;
+    isOwner: boolean;
   }[];
 }
 
@@ -48,22 +49,28 @@ const MemberManage = ({ data, setPageCount, pageCount }: MemberManagePropTypes) 
         <Spacing marginBottom="0.4" />
         <MemberLayout>
           {data?.writerNameCount !== 0 ? (
-            data?.writerNameList.map(({ writerNameId, writerName, postCount, commentCount }) => (
-              <MemberItemContainer key={writerNameId}>
-                <AdminProfileIcon />
-                <Name>{writerName}</Name>
-                <PostNumber>{postCount}</PostNumber>
-                <CommentNumber>{commentCount}</CommentNumber>
-                <ExpelBtn
-                  onClick={() => {
-                    setDeleteMemberId(writerNameId);
-                    handleShowModal();
-                  }}
-                >
-                  삭제하기
-                </ExpelBtn>
-              </MemberItemContainer>
-            ))
+            data?.writerNameList.map(
+              ({ writerNameId, writerName, postCount, commentCount, isOwner }) => (
+                <MemberItemContainer key={writerNameId}>
+                  <AdminProfileIcon />
+                  <Name>{writerName}</Name>
+                  <PostNumber>{postCount}</PostNumber>
+                  <CommentNumber>{commentCount}</CommentNumber>
+                  {!isOwner ? (
+                    <ExpelBtn
+                      onClick={() => {
+                        setDeleteMemberId(writerNameId);
+                        handleShowModal();
+                      }}
+                    >
+                      삭제하기
+                    </ExpelBtn>
+                  ) : (
+                    <Owner>글 모임 장</Owner>
+                  )}
+                </MemberItemContainer>
+              ),
+            )
           ) : (
             <EmptyContainer>
               <EmptyMemberText>아직 멤버가 없습니다.</EmptyMemberText>
@@ -201,6 +208,15 @@ const ExpelBtn = styled.button`
   &:hover {
     color: ${({ theme }) => theme.colors.mainViolet};
   }
+`;
+
+const Owner = styled.span`
+  margin-left: auto;
+
+  color: ${({ theme }) => theme.colors.black};
+
+  ${({ theme }) => theme.fonts.body5};
+  cursor: default;
 `;
 
 const EmptyContainer = styled.div`


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #357 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글 모임 장인 경우 삭제 버튼 대신 글 모임 장 텍스트로 대체

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 알게 된 부분은 딱히 없고 서버에서 넘겨주는 `isOwner`값이 true인 경우 삭제하기 버튼 대신 텍스트로 대체해줬습니다.
- 텍스트의 경우 버튼 기능을 하지 않아서 button 태그가 아닌 span 태그를 사용해주었고 cursor default로 설정해주었습니다 !

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

<img width="762" alt="스크린샷 2024-06-11 오후 8 29 06" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/820f6b7e-c047-4c24-9130-3228016d0044">
