### PR TITLE
[Feat] 글 상세 페이지 디테일 정보 추가

### DIFF
--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -174,7 +174,7 @@ const DateText = styled.p`
   ${({ theme }) => theme.fonts.subtitle4};
 `;
 
-const CuriousCount = styled.p`
+const CuriousCount = styled.div`
   display: flex;
   gap: 0.2rem;
   align-items: center;
@@ -183,7 +183,7 @@ const CuriousCount = styled.p`
   ${({ theme }) => theme.fonts.subtitle4};
 `;
 
-const ViewCount = styled.p`
+const ViewCount = styled.div`
   display: flex;
   gap: 0.2rem;
   align-items: center;
@@ -192,7 +192,7 @@ const ViewCount = styled.p`
   ${({ theme }) => theme.fonts.subtitle4};
 `;
 
-const CommentCount = styled.p`
+const CommentCount = styled.div`
   display: flex;
   gap: 0.2rem;
   align-items: center;

--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import Comment from './components/Comment';
 import CuriousBtn from './components/CuriousBtn';
@@ -8,7 +8,13 @@ import { useCheckPostAuth, useDeletePost, useGetPostDetail } from './hooks/queri
 import Error from '../error/Error';
 import Loading from '../loading/Loading';
 
-import { CheckboxIc, DefaultProfileIc } from './../../assets/svgs';
+import {
+  CheckboxIc,
+  DefaultProfileIc,
+  GroupChatIc,
+  GroupCuriousIc,
+  GroupViewIc,
+} from './../../assets/svgs';
 import Button from './../../components/commons/Button';
 import { AuthorizationHeader, UnAuthorizationHeader } from './../../components/commons/Header';
 import Spacing from './../../components/commons/Spacing';
@@ -68,7 +74,21 @@ const PostDetail = () => {
         <PostDetailContainer>
           <InfoTextBox>
             <TitleText>{postData?.title}</TitleText>
-            <DateText>{postData?.createdAt}</DateText>
+            <DetailBox>
+              <DateText>{postData?.createdAt} ·</DateText>
+              <CuriousCount>
+                <GroupCuriousIc />
+                {postData?.curiousCount}
+              </CuriousCount>
+              <ViewCount>
+                <GroupViewIc />
+                {postData?.hitsCount}
+              </ViewCount>
+              <CommentCount>
+                <GroupChatIc />
+                {postData?.commentCount}
+              </CommentCount>
+            </DetailBox>
           </InfoTextBox>
           {postAuth?.data?.data?.canEdit && (
             <ButtonWrapper>
@@ -96,7 +116,9 @@ const PostDetail = () => {
                 <WriterInfoText>{postData?.writerName}</WriterInfoText>
                 <GroupInfoText>{postData?.moimName}</GroupInfoText>
               </WriterInfoBox>
-              <WriterDesc>{postData?.writerInfo && '아직 작가소개를 작성하지 않았어요'}</WriterDesc>
+              <WriterDesc>
+                {!postData?.writerInfo ? '아직 작가소개를 작성하지 않았어요' : postData?.writerInfo}
+              </WriterDesc>
             </InfoWrapper>
           </WriterInfoContainer>
           {localStorage.accessToken && <CuriousBtn />}
@@ -137,12 +159,44 @@ const InfoTextBox = styled.div`
   width: 60rem;
 `;
 
+const DetailBox = styled.div`
+  display: flex;
+  gap: 0.8rem;
+`;
+
 const TitleText = styled.h1`
   color: ${({ theme }) => theme.colors.grayBlack};
   ${({ theme }) => theme.fonts.title1};
 `;
 
 const DateText = styled.p`
+  color: ${({ theme }) => theme.colors.gray70};
+  ${({ theme }) => theme.fonts.subtitle4};
+`;
+
+const CuriousCount = styled.p`
+  display: flex;
+  gap: 0.2rem;
+  align-items: center;
+
+  color: ${({ theme }) => theme.colors.gray70};
+  ${({ theme }) => theme.fonts.subtitle4};
+`;
+
+const ViewCount = styled.p`
+  display: flex;
+  gap: 0.2rem;
+  align-items: center;
+
+  color: ${({ theme }) => theme.colors.gray70};
+  ${({ theme }) => theme.fonts.subtitle4};
+`;
+
+const CommentCount = styled.p`
+  display: flex;
+  gap: 0.2rem;
+  align-items: center;
+
   color: ${({ theme }) => theme.colors.gray70};
   ${({ theme }) => theme.fonts.subtitle4};
 `;

--- a/src/pages/postDetail/apis/fetchPostDetail.ts
+++ b/src/pages/postDetail/apis/fetchPostDetail.ts
@@ -10,6 +10,9 @@ interface PostDetailRespnseTypes {
     topic: string;
     writerName: string;
     writerInfo: string;
+    hitsCount: number;
+    curiousCount: number;
+    commentCount: number;
   };
   status: number;
   message: string;
@@ -18,6 +21,7 @@ interface PostDetailRespnseTypes {
 const fetchPostDetail = async (postId: string) => {
   try {
     const { data } = await client.get<PostDetailRespnseTypes>(`/api/post/${postId}`);
+    console.log(data);
     return data;
   } catch (e) {
     console.log(e);

--- a/src/pages/postDetail/apis/fetchPostDetail.ts
+++ b/src/pages/postDetail/apis/fetchPostDetail.ts
@@ -21,7 +21,6 @@ interface PostDetailRespnseTypes {
 const fetchPostDetail = async (postId: string) => {
   try {
     const { data } = await client.get<PostDetailRespnseTypes>(`/api/post/${postId}`);
-    console.log(data);
     return data;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #361 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 궁금해요 수 & 조회 수 & 코멘트 수 추가
- [x] 작가 소개 띄우기

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 현재 바뀐 뷰에서 날짜가 2024년 6월 13일 15:59식으로 나와야 하는데 지금은 `24.06.13 15:59`식으로 서버에서 받아오고 있어서 이 부분 알맞게 보내달라고 요청한 상태입니다 !
- 위 부분 해결됐습니다 !

 **작가 소개 띄우기**

```tsx
              <WriterDesc>
                {!postData?.writerInfo ? '아직 작가소개를 작성하지 않았어요' : postData?.writerInfo}
              </WriterDesc>
```
삼항연산자 사용해서 작가소개 부분 코드 고쳤습니다 !

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

<img width="908" alt="스크린샷 2024-06-21 오전 4 39 16" src="https://github.com/Mile-Writings/Mile-Client/assets/96781926/b9ba4956-6de9-40f4-a3c3-937253a5833b">

