### PR TITLE
[Feat/#369] 마지막 캐러셀 슬라이드 이미지 영역 QA 수정

### DIFF
--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -52,6 +52,7 @@ const Main = () => {
       <DailyKeyword data={topic?.data} />
       <Spacing marginBottom="10" />
       <Introduction />
+      <Spacing marginBottom="10" />
       <Manual />
 
       <FaqLayout>

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Suspense, lazy } from 'react';
 import { useParams } from 'react-router-dom';
 
-import Ruler from './components/DailyKeyword';
+import DailyKeyword from './components/DailyKeyword';
 import FaqDropdown from './components/FaqDropdown';
 import Introduction from './components/Introduction';
 import Manual from './components/Manual';
@@ -49,7 +49,7 @@ const Main = () => {
         )}
       </GroupCarouselLayout>
 
-      <Ruler data={topic?.data} />
+      <DailyKeyword data={topic?.data} />
       <Introduction />
       <Manual />
       <FaqLayout>

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -26,41 +26,44 @@ const Main = () => {
       {localStorage.getItem('accessToken') ? <AuthorizationHeader /> : <UnAuthorizationHeader />}
       <Spacing marginBottom="6.4" />
       <OnBoarding />
+
       <GroupCarouselLayout>
         {isLoading || isFetching ? (
-          <CarouselComponentBox>
+          <>
             {groupLength && (
               <Suspense fallback={<SkeletonComponent groupLength={groupLength} />}>
                 <LazyCarousel data={data} groupLength={groupLength} />
               </Suspense>
             )}
-          </CarouselComponentBox>
+          </>
         ) : (
-          <CarouselWithTitleContainer>
+          <CarouselBox>
             <CarouselTitle>마일과 함께하고 있는 글 모임이에요</CarouselTitle>
-            <CarouselComponentBox>
-              {groupLength && (
-                <Suspense fallback={<SkeletonComponent groupLength={groupLength} />}>
-                  <LazyCarousel data={data} groupLength={groupLength} />
-                </Suspense>
-              )}
-            </CarouselComponentBox>
-          </CarouselWithTitleContainer>
+            {groupLength && (
+              <Suspense fallback={<SkeletonComponent groupLength={groupLength} />}>
+                <LazyCarousel data={data} groupLength={groupLength} />
+              </Suspense>
+            )}
+          </CarouselBox>
         )}
       </GroupCarouselLayout>
+      <Spacing marginBottom="10" />
 
       <DailyKeyword data={topic?.data} />
+      <Spacing marginBottom="10" />
       <Introduction />
       <Manual />
+
       <FaqLayout>
-        <FaqTitleWithDropDownContainer>
+        <FaqContainer>
           <FaqTitle>자주 묻는 질문</FaqTitle>
           <Spacing marginBottom="3.6" />
           {FAQ_DATA.map(({ id, question, answer }) => (
             <FaqDropdown key={id} id={id} question={question} answer={answer} />
           ))}
-        </FaqTitleWithDropDownContainer>
+        </FaqContainer>
       </FaqLayout>
+
       <Spacing marginBottom="17.3" />
       <Footer />
     </MainPageWrapper>
@@ -79,44 +82,31 @@ const MainPageWrapper = styled.div`
 
 const GroupCarouselLayout = styled.section`
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 100%;
 `;
 
-const CarouselWithTitleContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
+const CarouselBox = styled.div`
+  cursor: default;
 `;
 
-const CarouselTitle = styled.p`
-  justify-content: flex-start;
-  width: fit-content;
+const CarouselTitle = styled.h1`
   padding-top: 7.2rem;
 
   ${({ theme }) => theme.fonts.title3};
 `;
 
-const CarouselComponentBox = styled.section`
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 10rem;
-`;
-
 const FaqLayout = styled.section`
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 `;
 
-const FaqTitle = styled.p`
-  ${({ theme }) => theme.fonts.title3};
+const FaqContainer = styled.div`
+  cursor: default;
 `;
 
-const FaqTitleWithDropDownContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  width: fit-content;
+const FaqTitle = styled.h3`
+  ${({ theme }) => theme.fonts.title3};
 `;

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -54,8 +54,9 @@ const CarouselContent = ({
           />
         )}
       </CarouselContentLayout>
+
       {isLast && (
-        <GroupRoutingBtnLayout>
+        <LastSlideBtnLayout>
           <GroupRoutingText>
             이 모임에 대해서
             <br /> 더 궁금하신가요?
@@ -64,7 +65,7 @@ const CarouselContent = ({
           <GroupRoutingBtnBox>
             <MainGroupRoutingBtnIcon onClick={handleRoutingGroup} />
           </GroupRoutingBtnBox>
-        </GroupRoutingBtnLayout>
+        </LastSlideBtnLayout>
       )}
     </CarouselWrapper>
   );
@@ -128,13 +129,15 @@ const Image = styled.img<{ isLast: boolean }>`
   border-radius: 8px;
 `;
 
-const GroupRoutingBtnLayout = styled.section`
+const LastSlideBtnLayout = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   margin-left: 5rem;
 
   text-align: center;
+
+  cursor: default;
 `;
 
 const GroupRoutingText = styled.p`
@@ -145,9 +148,7 @@ const GroupRoutingText = styled.p`
 `;
 
 const GroupRoutingBtnBox = styled.div`
-  & > svg {
-    cursor: pointer;
-  }
+  cursor: pointer;
 
   & > svg:hover {
     path {

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -35,44 +35,46 @@ const CarouselContent = ({
   };
 
   return (
-    <CarouselContentWrapper>
-      {imageUrl && (
-        <>
-          <ContentLayout onClick={handleRoutingDetail}>
-            <Topic>{topicName}</Topic>
-            <MainText>{postTitle}</MainText>
-            <Spacing marginBottom="2" />
-            <SubText isLast={isLast} isContainPhoto={isContainPhoto}>
-              {postContent}
-            </SubText>
-          </ContentLayout>
-          {isContainPhoto && (
-            <Image
-              src={imageUrl}
-              isLast={isLast}
-              alt="group-content-image"
-              onClick={handleRoutingDetail}
-            />
-          )}
-        </>
-      )}
+    <CarouselWrapper>
+      <CarouselContentWrapper>
+        <ContentLayout onClick={handleRoutingDetail}>
+          <Topic>{topicName}</Topic>
+          <MainText>{postTitle}</MainText>
+          <Spacing marginBottom="2" />
+          <SubText isLast={isLast} isContainPhoto={isContainPhoto}>
+            {postContent}
+          </SubText>
+        </ContentLayout>
+        {isContainPhoto && (
+          <Image
+            src={imageUrl || ''}
+            isLast={isLast}
+            alt={`${groupId}-content-image`}
+            onClick={handleRoutingDetail}
+          />
+        )}
+      </CarouselContentWrapper>
       {isLast && (
         <GroupRoutingBtnLayout>
-          <GroupRoutingBox>
+          <GroupRoutingText>
             이 모임에 대해서
             <br /> 더 궁금하신가요?
-          </GroupRoutingBox>
+          </GroupRoutingText>
           <Spacing marginBottom="1.6" />
           <GroupRoutingBtnBox>
             <MainGroupRoutingBtnIcon onClick={() => handleRoutingGroup()} />
           </GroupRoutingBtnBox>
         </GroupRoutingBtnLayout>
       )}
-    </CarouselContentWrapper>
+    </CarouselWrapper>
   );
 };
 
 export default CarouselContent;
+
+const CarouselWrapper = styled.section`
+  display: flex;
+`;
 
 const CarouselContentWrapper = styled.div`
   display: flex;
@@ -100,7 +102,6 @@ const ContentLayout = styled.div`
 `;
 
 const SubText = styled.p<{ isContainPhoto: boolean; isLast: boolean }>`
-  display: -webkit-box;
   width: ${({ isContainPhoto, isLast }) =>
     isContainPhoto && isLast
       ? '47.8rem'
@@ -134,12 +135,12 @@ const GroupRoutingBtnLayout = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-left: 4.2rem;
+  margin-left: 5rem;
 
   text-align: center;
 `;
 
-const GroupRoutingBox = styled.p`
+const GroupRoutingText = styled.p`
   width: 12.3rem;
 
   color: ${({ theme }) => theme.colors.black};

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -36,15 +36,15 @@ const CarouselContent = ({
 
   return (
     <CarouselWrapper>
-      <CarouselContentWrapper>
-        <ContentLayout onClick={handleRoutingDetail}>
+      <CarouselContentLayout>
+        <ContentContainer onClick={handleRoutingDetail}>
           <Topic>{topicName}</Topic>
-          <MainText>{postTitle}</MainText>
+          <Title>{postTitle}</Title>
           <Spacing marginBottom="2" />
           <SubText isLast={isLast} isContainPhoto={isContainPhoto}>
             {postContent}
           </SubText>
-        </ContentLayout>
+        </ContentContainer>
         {isContainPhoto && (
           <Image
             src={imageUrl || ''}
@@ -53,7 +53,7 @@ const CarouselContent = ({
             onClick={handleRoutingDetail}
           />
         )}
-      </CarouselContentWrapper>
+      </CarouselContentLayout>
       {isLast && (
         <GroupRoutingBtnLayout>
           <GroupRoutingText>
@@ -76,7 +76,7 @@ const CarouselWrapper = styled.section`
   display: flex;
 `;
 
-const CarouselContentWrapper = styled.div`
+const CarouselContentLayout = styled.div`
   display: flex;
   gap: 3.6rem;
   padding: 3.6rem;
@@ -85,23 +85,23 @@ const CarouselContentWrapper = styled.div`
   border-radius: 8px;
 `;
 
-const Topic = styled.div`
+const Topic = styled.h1`
   color: ${({ theme }) => theme.colors.gray70};
   ${({ theme }) => theme.fonts.body6};
 `;
 
-const MainText = styled.p`
+const Title = styled.h2`
   ${({ theme }) => theme.fonts.title10};
 `;
 
-const ContentLayout = styled.div`
+const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
 
   cursor: pointer;
 `;
 
-const SubText = styled.p<{ isContainPhoto: boolean; isLast: boolean }>`
+const SubText = styled.span<{ isContainPhoto: boolean; isLast: boolean }>`
   width: ${({ isContainPhoto, isLast }) =>
     isContainPhoto && isLast
       ? '47.8rem'

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -37,7 +37,7 @@ const CarouselContent = ({
   return (
     <CarouselWrapper>
       <CarouselContentLayout>
-        <ContentContainer onClick={handleRoutingDetail}>
+        <ContentContainer onClick={() => handleRoutingDetail}>
           <Topic>{topicName}</Topic>
           <Title>{postTitle}</Title>
           <Spacing marginBottom="2" />
@@ -50,7 +50,7 @@ const CarouselContent = ({
             src={imageUrl || ''}
             isLast={isLast}
             alt={`${groupId}-content-image`}
-            onClick={handleRoutingDetail}
+            onClick={() => handleRoutingDetail}
           />
         )}
       </CarouselContentLayout>
@@ -62,7 +62,7 @@ const CarouselContent = ({
           </GroupRoutingText>
           <Spacing marginBottom="1.6" />
           <GroupRoutingBtnBox>
-            <MainGroupRoutingBtnIcon onClick={() => handleRoutingGroup()} />
+            <MainGroupRoutingBtnIcon onClick={() => handleRoutingGroup} />
           </GroupRoutingBtnBox>
         </GroupRoutingBtnLayout>
       )}
@@ -97,8 +97,6 @@ const Title = styled.h2`
 const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-
-  cursor: pointer;
 `;
 
 const SubText = styled.span<{ isContainPhoto: boolean; isLast: boolean }>`
@@ -127,7 +125,6 @@ const Image = styled.img<{ isLast: boolean }>`
   height: 16.8rem;
   object-fit: cover;
 
-  cursor: pointer;
   border-radius: 8px;
 `;
 

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -75,6 +75,7 @@ export default CarouselContent;
 
 const CarouselWrapper = styled.section`
   display: flex;
+  gap: 5rem;
 `;
 
 const CarouselContentLayout = styled.div`
@@ -133,7 +134,6 @@ const LastSlideBtnLayout = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-left: 5rem;
 
   text-align: center;
 

--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -37,7 +37,7 @@ const CarouselContent = ({
   return (
     <CarouselWrapper>
       <CarouselContentLayout>
-        <ContentContainer onClick={() => handleRoutingDetail}>
+        <ContentContainer onClick={handleRoutingDetail}>
           <Topic>{topicName}</Topic>
           <Title>{postTitle}</Title>
           <Spacing marginBottom="2" />
@@ -50,7 +50,7 @@ const CarouselContent = ({
             src={imageUrl || ''}
             isLast={isLast}
             alt={`${groupId}-content-image`}
-            onClick={() => handleRoutingDetail}
+            onClick={handleRoutingDetail}
           />
         )}
       </CarouselContentLayout>
@@ -62,7 +62,7 @@ const CarouselContent = ({
           </GroupRoutingText>
           <Spacing marginBottom="1.6" />
           <GroupRoutingBtnBox>
-            <MainGroupRoutingBtnIcon onClick={() => handleRoutingGroup} />
+            <MainGroupRoutingBtnIcon onClick={handleRoutingGroup} />
           </GroupRoutingBtnBox>
         </GroupRoutingBtnLayout>
       )}

--- a/src/pages/main/components/GroupCarousel.tsx
+++ b/src/pages/main/components/GroupCarousel.tsx
@@ -18,7 +18,7 @@ import Spacing from '../../../components/commons/Spacing';
 
 export interface carouselItemPropTypes {
   moimId?: string;
-  data: groupPropTypes[] | undefined;
+  data?: groupPropTypes[];
   groupLength: number;
 }
 

--- a/src/pages/main/components/GroupCarousel.tsx
+++ b/src/pages/main/components/GroupCarousel.tsx
@@ -112,6 +112,8 @@ const GroupButtonContainer = styled.button`
 
 const CarouselContainer = styled.div`
   display: flex;
+
+  cursor: pointer;
 `;
 
 const CarouselBox = styled(Slider)`

--- a/src/pages/main/components/GroupCarousel.tsx
+++ b/src/pages/main/components/GroupCarousel.tsx
@@ -43,34 +43,34 @@ const GroupCarousel = ({ data }: carouselItemPropTypes) => {
       {data?.map((moim) => (
         <CarouselWrapper key={moim.moimId}>
           <Spacing marginBottom="3.6" />
-          <CarouselWithButtonLayout key={moim.moimId}>
-            <GroupButtonContainer
-              onClick={() => handleButtonOnClick(moim.moimId)}
-              onMouseOver={() => setIsHovered(true)}
-              onMouseLeave={() => setIsHovered(false)}
-            >
-              {moim.moimName}
-              {isHovered ? <MainIcnArrowPurpleIcon /> : <MainIcnArrowBlackIcon />}
-            </GroupButtonContainer>
-            <Spacing marginBottom="1.6" />
-            <CarouselContainer>
-              <CarouselBox {...settings} className="main">
-                {moim.moimPosts.map((post, index) => (
-                  <CarouselContent
-                    key={index}
-                    topicName={post.topicName}
-                    imageUrl={post.imageUrl}
-                    postTitle={post.postTitle}
-                    postContent={post.postContent}
-                    postId={post.postId}
-                    isContainPhoto={post.isContainPhoto}
-                    groupId={moim.moimId}
-                    isLast={index === moim.moimPosts.length - 1}
-                  />
-                ))}
-              </CarouselBox>
+          <GroupButton
+            type="button"
+            onClick={() => handleButtonOnClick(moim.moimId)}
+            onMouseOver={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+          >
+            {moim.moimName}
+            {isHovered ? <MainIcnArrowPurpleIcon /> : <MainIcnArrowBlackIcon />}
+          </GroupButton>
+          <Spacing marginBottom="1.6" />
+
+          <CarouselLayout>
+            <CarouselContainer {...settings} className="main">
+              {moim.moimPosts.map((post, index) => (
+                <CarouselContent
+                  key={index}
+                  topicName={post.topicName}
+                  imageUrl={post.imageUrl}
+                  postTitle={post.postTitle}
+                  postContent={post.postContent}
+                  postId={post.postId}
+                  isContainPhoto={post.isContainPhoto}
+                  groupId={moim.moimId}
+                  isLast={index === moim.moimPosts.length - 1}
+                />
+              ))}
             </CarouselContainer>
-          </CarouselWithButtonLayout>
+          </CarouselLayout>
         </CarouselWrapper>
       ))}
     </>
@@ -80,19 +80,13 @@ const GroupCarousel = ({ data }: carouselItemPropTypes) => {
 export default GroupCarousel;
 
 const CarouselWrapper = styled.div`
-  display: flex;
   flex-direction: column;
 `;
 
-const CarouselWithButtonLayout = styled.div`
-  margin-bottom: 3.2rem;
-`;
-
-const GroupButtonContainer = styled.button`
+const GroupButton = styled.button`
   display: flex;
   gap: 0.8rem;
   align-items: center;
-  justify-content: flex-start;
   padding: 0.6rem 1rem;
 
   color: ${({ theme }) => theme.colors.black};
@@ -110,13 +104,13 @@ const GroupButtonContainer = styled.button`
   }
 `;
 
-const CarouselContainer = styled.div`
+const CarouselLayout = styled.div`
   display: flex;
 
   cursor: pointer;
 `;
 
-const CarouselBox = styled(Slider)`
+const CarouselContainer = styled(Slider)`
   width: 93rem;
   height: 24rem;
 

--- a/src/pages/main/components/GroupCarousel.tsx
+++ b/src/pages/main/components/GroupCarousel.tsx
@@ -19,7 +19,7 @@ import Spacing from '../../../components/commons/Spacing';
 export interface carouselItemPropTypes {
   moimId?: string;
   data: groupPropTypes[] | undefined;
-  groupLength: number | undefined;
+  groupLength: number;
 }
 
 const GroupCarousel = ({ data }: carouselItemPropTypes) => {
@@ -36,7 +36,7 @@ const GroupCarousel = ({ data }: carouselItemPropTypes) => {
   const handleButtonOnClick = (groupId: string) => {
     navigate(`/group/${groupId}`);
   };
-  const [IsHovered, setIsHovered] = useState<boolean>(false);
+  const [isHovered, setIsHovered] = useState<boolean>(false);
 
   return (
     <>
@@ -50,7 +50,7 @@ const GroupCarousel = ({ data }: carouselItemPropTypes) => {
               onMouseLeave={() => setIsHovered(false)}
             >
               {moim.moimName}
-              {IsHovered ? <MainIcnArrowPurpleIcon /> : <MainIcnArrowBlackIcon />}
+              {isHovered ? <MainIcnArrowPurpleIcon /> : <MainIcnArrowBlackIcon />}
             </GroupButtonContainer>
             <Spacing marginBottom="1.6" />
             <CarouselContainer>

--- a/src/pages/main/components/Introduction.tsx
+++ b/src/pages/main/components/Introduction.tsx
@@ -16,7 +16,7 @@ const Introduction = () => {
   const handleOnClick = () => {
     navigate('/group/MQ==');
   };
-  const [IsHovered, setIsHovered] = useState<boolean>(false);
+  const [IsHovered, setIsHovered] = useState(false);
 
   return (
     <IntroductionWrapper>
@@ -59,7 +59,7 @@ const IntroductionWrapper = styled.section`
   align-items: center;
   justify-content: center;
   width: 100%;
-  padding: 10.1rem 21.8rem 10rem 28.4rem;
+  padding: 10.1rem 21.8rem 0 28.4rem;
 
   background-color: ${({ theme }) => theme.colors.backGroundViolet};
 `;

--- a/src/pages/main/components/Introduction.tsx
+++ b/src/pages/main/components/Introduction.tsx
@@ -30,22 +30,23 @@ const Introduction = () => {
         <Spacing marginBottom="0.8" />
         <SubText>{INTRODUCTION_DATA[0].subText}</SubText>
         <Spacing marginBottom="8" />
-        <GroupRoutingButtonBox
+        <GroupRoutingButton
+          type="button"
           onClick={handleOnClick}
           onMouseOver={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
           마일 글 모임 바로가기
           {IsHovered ? <MainIcnArrowPurpleIcon /> : <MainArrowWhiteIc />}
-        </GroupRoutingButtonBox>
+        </GroupRoutingButton>
       </MileMakersTextLayout>
-      <IntroduceZakmiBox>
+      <IntroduceMileLayout>
         <HookText>{INTRODUCTION_DATA[0].hookText}</HookText>
         <Spacing marginBottom="0.4" />
         <GreetingText>{INTRODUCTION_DATA[0].greetingText}</GreetingText>
         <Spacing marginBottom="3" />
         <DiscriptionText>{INTRODUCTION_DATA[0].discriptionText}</DiscriptionText>
-      </IntroduceZakmiBox>
+      </IntroduceMileLayout>
     </IntroductionWrapper>
   );
 };
@@ -54,11 +55,10 @@ export default Introduction;
 
 const IntroductionWrapper = styled.section`
   display: flex;
-  gap: 7.4rem;
+  gap: 10.2rem;
   align-items: center;
   justify-content: center;
   width: 100%;
-  margin-top: 10rem;
   padding: 10.1rem 21.8rem 10rem 28.4rem;
 
   background-color: ${({ theme }) => theme.colors.backGroundViolet};
@@ -67,26 +67,24 @@ const IntroductionWrapper = styled.section`
 const MileMakersTextLayout = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const MainText = styled.p`
-  width: fit-content;
 
   white-space: nowrap;
+`;
+
+const MainText = styled.h1`
   ${({ theme }) => theme.fonts.title3};
 `;
 
-const SubText = styled.p`
+const SubText = styled.span`
   color: ${({ theme }) => theme.colors.darkViolet};
   ${({ theme }) => theme.fonts.subtitle3};
 `;
 
-const GroupRoutingButtonBox = styled.button`
-  display: inline-flex;
+const GroupRoutingButton = styled.button`
+  display: flex;
   gap: 0.8rem;
   align-items: center;
   width: fit-content;
-  height: 3.6rem;
   padding: 0.6rem 1rem;
 
   color: ${({ theme }) => theme.colors.white};
@@ -105,11 +103,10 @@ const GroupRoutingButtonBox = styled.button`
   }
 `;
 
-const IntroduceZakmiBox = styled.div`
+const IntroduceMileLayout = styled.div`
   display: flex;
   flex-direction: column;
   width: 40rem;
-  height: 26.7rem;
   padding: 3.6rem;
 
   background-color: ${({ theme }) => theme.colors.white};
@@ -117,14 +114,12 @@ const IntroduceZakmiBox = styled.div`
   border-radius: 1rem;
 `;
 
-const HookText = styled.p`
+const HookText = styled.span`
   color: ${({ theme }) => theme.colors.gray70};
   ${({ theme }) => theme.fonts.subtitle4};
 `;
 
-const GreetingText = styled.p`
-  width: fit-content;
-
+const GreetingText = styled.span`
   white-space: nowrap;
   ${({ theme }) => theme.fonts.title5};
 `;

--- a/src/pages/main/components/Manual.tsx
+++ b/src/pages/main/components/Manual.tsx
@@ -13,21 +13,19 @@ import Spacing from '../../../components/commons/Spacing';
 const Manual = () => {
   return (
     <ManualWrapper>
+      <ManualTitle>마일 메뉴얼</ManualTitle>
+      <Spacing marginBottom="3.6" />
       <ManualLayout>
-        <ManualTitle>마일 메뉴얼</ManualTitle>
-        <Spacing marginBottom="3.6" />
-        <ManualContainer>
-          <ManualRow>
-            <MainManualMakeIc />
-            <MainManualJoinIc />
-            <MainManualWriteIc />
-          </ManualRow>
-          <ManualRow>
-            <MainManualShareIc />
-            <MainManualCuriousIc />
-            <MainManualLookIc />
-          </ManualRow>
-        </ManualContainer>
+        <ManualRow>
+          <MainManualMakeIc />
+          <MainManualJoinIc />
+          <MainManualWriteIc />
+        </ManualRow>
+        <ManualRow>
+          <MainManualShareIc />
+          <MainManualCuriousIc />
+          <MainManualLookIc />
+        </ManualRow>
       </ManualLayout>
     </ManualWrapper>
   );
@@ -38,22 +36,19 @@ export default Manual;
 const ManualWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  margin: 0 auto;
   padding-bottom: 10rem;
-`;
-
-const ManualLayout = styled.div`
-  cursor: default;
 `;
 
 const ManualTitle = styled.h1`
   display: flex;
   margin-top: 10rem;
   ${({ theme }) => theme.fonts.title3};
+
+  cursor: default;
 `;
 
-const ManualContainer = styled.section`
+const ManualLayout = styled.section`
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;

--- a/src/pages/main/components/Manual.tsx
+++ b/src/pages/main/components/Manual.tsx
@@ -12,11 +12,11 @@ import Spacing from '../../../components/commons/Spacing';
 
 const Manual = () => {
   return (
-    <ManualLayout>
-      <TitleWithManualContainer>
+    <ManualWrapper>
+      <ManualLayout>
         <ManualTitle>마일 메뉴얼</ManualTitle>
         <Spacing marginBottom="3.6" />
-        <ManualBox>
+        <ManualContainer>
           <ManualRow>
             <MainManualMakeIc />
             <MainManualJoinIc />
@@ -27,15 +27,15 @@ const Manual = () => {
             <MainManualCuriousIc />
             <MainManualLookIc />
           </ManualRow>
-        </ManualBox>
-      </TitleWithManualContainer>
-    </ManualLayout>
+        </ManualContainer>
+      </ManualLayout>
+    </ManualWrapper>
   );
 };
 
 export default Manual;
 
-const ManualLayout = styled.section`
+const ManualWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -43,32 +43,24 @@ const ManualLayout = styled.section`
   padding-bottom: 10rem;
 `;
 
-const TitleWithManualContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  width: fit-content;
+const ManualLayout = styled.div`
+  cursor: default;
 `;
 
-const ManualTitle = styled.div`
+const ManualTitle = styled.h1`
   display: flex;
-  justify-content: flex-start;
   margin-top: 10rem;
   ${({ theme }) => theme.fonts.title3};
 `;
 
-const ManualBox = styled.div`
+const ManualContainer = styled.section`
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
-  align-items: center;
-  justify-content: center;
   width: 92.8rem;
 `;
 
 const ManualRow = styled.div`
   display: flex;
   gap: 2rem;
-  align-items: center;
-  justify-content: center;
 `;

--- a/src/utils/apis/axios.ts
+++ b/src/utils/apis/axios.ts
@@ -1,11 +1,10 @@
 import axios from 'axios';
 
-// const baseUrl = import.meta.env.VITE_BASE_URL;
+const baseUrl = import.meta.env.VITE_BASE_URL;
 const devBaseUrl = import.meta.env.VITE_DEV_BASE_URL;
 
-
 export const client = axios.create({
-  baseURL: `${devBaseUrl}`,
+  baseURL: `${baseUrl}`,
   headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
 });
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closed #369 


### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 캐러셀 마지막 슬라이드일 때 이미지 영역에 텍스트 침범하지 않게 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- `이 모임에 대해서 더 궁금하신가요?` 부분을 다른 flex 영역으로 분리해주고 감싸고 있는 바깥 레이아웃에 gap을 줘서 해결했습니다

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

<img width="915" alt="스크린샷 2024-07-25 오후 5 17 09" src="https://github.com/user-attachments/assets/f4f23197-5ea3-401c-be07-669087d75c78">
