### PR TITLE
[Fix/#380] 에디터 페이지 썸네일 추가 버튼 호버값, active값 수정, 썸네일 Border-radius 재적용

### DIFF
--- a/src/assets/svgs/editorThuminputIcnUnactive.svg
+++ b/src/assets/svgs/editorThuminputIcnUnactive.svg
@@ -1,6 +1,6 @@
 <svg width="55" height="55" viewBox="0 0 55 55" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="0.546875" y="0.925781" width="53" height="53" rx="26.5" fill="white"/>
-<rect x="0.546875" y="0.925781" width="53" height="53" rx="26.5" stroke="white"/>
+<rect x="0.546875" y="0.925781" width="53" height="53" rx="26.5" />
 <mask id="mask0_567_30802" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="12" y="12" width="31" height="31">
 <rect x="12.0469" y="12.4258" width="30" height="30" fill="#D9D9D9"/>
 </mask>

--- a/src/assets/svgs/index.tsx
+++ b/src/assets/svgs/index.tsx
@@ -55,10 +55,7 @@ export { default as EditorDropIcnActiveIc } from './editorDropIcnActive.svg?reac
 export { default as EditorDropIcnActiveOpenIc } from './editorDropIcnActiveopen.svg?react';
 export { default as GroupThumbnailImgIc } from './groupThumbnailImg.svg?react';
 
-export {
-  default as EditorThuminputIcnActiveIc,
-  default as EditorThuminputIcnHoverIc,
-} from './editorThuminputIcnHover.svg?react';
+export { default as EditorThuminputIcnActiveIc } from './editorThuminputIcnActive.svg?react';
 export { default as EditorThuminputIcnUnactiveIc } from './editorThuminputIcnUnactive.svg?react';
 export { default as GroupCardThumnailImgIc } from './groupCardThumnailImg.svg?react';
 

--- a/src/pages/postPage/components/ImageUpload.tsx
+++ b/src/pages/postPage/components/ImageUpload.tsx
@@ -66,7 +66,7 @@ const ThumbNailGradient = styled.div`
   width: 100%;
 
   background: ${({ theme }) => theme.colors.thumbnailGradient};
-  border-radius: 10px;
+  border-radius: 0 0 10px 10px;
 `;
 
 const ThumbNailImg = styled.img<{ $imgExist: string }>`
@@ -76,7 +76,7 @@ const ThumbNailImg = styled.img<{ $imgExist: string }>`
   height: 30.7rem;
   object-fit: cover;
 
-  border-radius: 10px;
+  border-radius: 0 0 10px 10px;
   ${({ $imgExist }) => $imgExist && $imgExist.length === 0 && 'content: "";'}
 `;
 
@@ -101,7 +101,6 @@ const EditorThuminputIcnUnactiveIcon = styled(EditorThuminputIcnUnactiveIc)`
   :hover {
     path {
       fill: ${({ theme }) => theme.colors.mainViolet};
-      stroke: ${({ theme }) => theme.colors.mainViolet};
     }
 
     rect {

--- a/src/pages/postPage/components/ImageUpload.tsx
+++ b/src/pages/postPage/components/ImageUpload.tsx
@@ -103,6 +103,10 @@ const EditorThuminputIcnUnactiveIcon = styled(EditorThuminputIcnUnactiveIc)`
       fill: ${({ theme }) => theme.colors.mainViolet};
       stroke: ${({ theme }) => theme.colors.mainViolet};
     }
+
+    rect {
+      stroke: ${({ theme }) => theme.colors.mainViolet};
+    }
   }
 `;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #380 

### todo 



<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 에디터 페이지 썸네일 추가 버튼 호버값, active값 수정,
- [x] 썸네일 Border-radius 재적용

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
-  svg의 Rect값에 stroke를 먹여야하는데 ,, 어떻게 하지 하다가 Path랑 똑같이 적용해봤는데 되더라구요 ? 신기함

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
https://github.com/user-attachments/assets/ddeffb93-fee6-4444-844b-4a0d4a804b21
