### PR TITLE
[Hotfix/#390] 게시글 수정하기로 들어왔을 경우 임시저장 글 존재 여부 api 쏘지 않도록 수정

### DIFF
--- a/src/pages/postPage/PostPage.tsx
+++ b/src/pages/postPage/PostPage.tsx
@@ -198,7 +198,6 @@ const PostPage = () => {
     useGetTempSaveContent(tempPostId || '', continueTempPost || false);
 
   // 최초 뷰 들어왔을 때 임시저장 이어쓸지 confirm 창
-  console.log(type);
   useEffect(() => {
     if (type === 'post' && isTemporaryPostExist && !continueTempPost) {
       setEditorModalType('continueTempSave');

--- a/src/pages/postPage/PostPage.tsx
+++ b/src/pages/postPage/PostPage.tsx
@@ -172,7 +172,7 @@ const PostPage = () => {
   // 모임 ID, url에서 받아오기
   const { groupId, type } = useParams() as { groupId: string; type: string };
   // 임시저장 값 여부 확인 (서버값)
-  const { isTemporaryPostExist, tempPostId } = useTempSaveFlag(groupId || '');
+  const { isTemporaryPostExist, tempPostId } = useTempSaveFlag(groupId || '', type === 'post');
   // 임시저장 이어쓰기 yes 인 경우 판별
   const [continueTempPost, setContinueTempPost] = useState(false);
   // 수정하기, 임시저장 postId 저장
@@ -198,6 +198,7 @@ const PostPage = () => {
     useGetTempSaveContent(tempPostId || '', continueTempPost || false);
 
   // 최초 뷰 들어왔을 때 임시저장 이어쓸지 confirm 창
+  console.log(type);
   useEffect(() => {
     if (type === 'post' && isTemporaryPostExist && !continueTempPost) {
       setEditorModalType('continueTempSave');

--- a/src/pages/postPage/hooks/queries.ts
+++ b/src/pages/postPage/hooks/queries.ts
@@ -94,10 +94,14 @@ interface TempSaveFlagQueryResult {
   error: Error | null;
 }
 
-export const useTempSaveFlag = (groupId: string): TempSaveFlagQueryResult => {
+export const useTempSaveFlag = (
+  groupId: string,
+  tempSaveFlag: boolean,
+): TempSaveFlagQueryResult => {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: [QUERY_KEY_POST.getTempSaveFlag, groupId],
+    queryKey: [QUERY_KEY_POST.getTempSaveFlag, groupId, tempSaveFlag],
     queryFn: () => fetchTempSaveFlag(groupId),
+    enabled: !!tempSaveFlag,
   });
 
   const isTemporaryPostExist = data && data?.data?.isTemporaryPostExist;

--- a/src/pages/postPage/hooks/queries.ts
+++ b/src/pages/postPage/hooks/queries.ts
@@ -94,14 +94,11 @@ interface TempSaveFlagQueryResult {
   error: Error | null;
 }
 
-export const useTempSaveFlag = (
-  groupId: string,
-  tempSaveFlag: boolean,
-): TempSaveFlagQueryResult => {
+export const useTempSaveFlag = (groupId: string, isPostView: boolean): TempSaveFlagQueryResult => {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: [QUERY_KEY_POST.getTempSaveFlag, groupId, tempSaveFlag],
+    queryKey: [QUERY_KEY_POST.getTempSaveFlag, groupId, isPostView],
     queryFn: () => fetchTempSaveFlag(groupId),
-    enabled: !!tempSaveFlag,
+    enabled: !!isPostView,
   });
 
   const isTemporaryPostExist = data && data?.data?.isTemporaryPostExist;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #390 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 게시글 수정하기로 들어왔을 경우 임시저장 글 존재 여부 api 쏘지 않도록 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
```typescript
export const useTempSaveFlag = (
  groupId: string,
  tempSaveFlag: boolean,
): TempSaveFlagQueryResult => {
  const { data, isLoading, isError, error } = useQuery({
    queryKey: [QUERY_KEY_POST.getTempSaveFlag, groupId, tempSaveFlag],
    queryFn: () => fetchTempSaveFlag(groupId),
    ✅ enabled: !!tempSaveFlag, ✅
  });

  const isTemporaryPostExist = data && data?.data?.isTemporaryPostExist;
  const tempPostId = data && data?.data?.postId;

  return { isTemporaryPostExist, tempPostId, isLoading, isError, error };
};
```

임시저장 글이 있는지 없는지 여부에 따라 
<img width="275" alt="image" src="https://github.com/user-attachments/assets/3418241f-35f5-464a-8c57-e91721a1beb2">
이 모달을 띄워야해서 에디터 페이지에 접근하면 `임시저장 글 존재 여부 확인하는 api`를 쏘게 했었는데 그러다보니 수정하기로 들어온 경우에도 해당 api를 쏘더라구요

그래서 `enabled` 속성으로 수정하기로 들어왔을 경우가 아닌 경우 (**기존 글 작성 플로우로 들어온 경우**)에만 api 쏘도록 수정해두었습니다 !

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
- 없

## 📌스크린샷(선택)
- 기존 글 작성으로 들어왔을 경우 (현재재 권한이 있어도 401이 뜨는 이슈가 있긴 합니다만 .. 이 피알에선 안해두었어요)

https://github.com/user-attachments/assets/14ca1205-ada4-44ac-b5ed-7be9b89ba5a5


- 수정하기로 들어왔을 경우

https://github.com/user-attachments/assets/29080923-104e-471c-b737-17476a283781

