### PR TITLE
[ Hotfix/#409] group invite error handling (to main)

### DIFF
--- a/src/pages/groupInvite/GroupInvite.tsx
+++ b/src/pages/groupInvite/GroupInvite.tsx
@@ -43,9 +43,6 @@ const GroupInvite = () => {
     }
   }, [error, isError, groupId]);
 
-  // if (errorLoading) {
-  //   return <Loading />;
-  // } else {
   return (
     <GroupInviteWrapper>
       <DefaultHeader />

--- a/src/pages/groupInvite/GroupInvite.tsx
+++ b/src/pages/groupInvite/GroupInvite.tsx
@@ -33,6 +33,9 @@ const GroupInvite = () => {
         } else if (status === 404) {
           alert('존재하지 않는 글모임입니다.');
           navigate('/');
+        } else if (status === 500) {
+          alert('예상치 못한 에러입니다. 다시 시도해주세요.');
+          navigate('/error');
         } else {
           console.error('groupInvite' + status, error.response.data.status);
         }

--- a/src/pages/groupInvite/GroupInvite.tsx
+++ b/src/pages/groupInvite/GroupInvite.tsx
@@ -5,8 +5,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { DefaultHeader } from '../../components/commons/Header';
 import Spacing from '../../components/commons/Spacing';
-import useNavigateLoginWithPath from '../../hooks/useNavigateLoginWithPath';
-
 import GroupInfo from './components/GroupInfo';
 import Title from './components/Title';
 import UserInfoInput from './components/UserInfoInput';
@@ -19,31 +17,26 @@ const GroupInvite = () => {
   const { moimTitle, imageUrl, leader, foundedDate, memberCount, description, error, isError } =
     useGetGroupInfo(groupId);
 
-  const { navigateToLogin } = useNavigateLoginWithPath();
-
   useEffect(() => {
     if (isError && isAxiosError(error)) {
       if (error.response && error.response.status) {
         const { status } = error.response;
+        console.log(status);
         if (status === 400) {
           if (error.response.data.status === 40010 || error.response.data.status === 40014) {
             alert('존재하지 않는 글모임입니다.');
-            navigateToLogin();
+            navigate('/');
           } else if (error.response.data.status === 40016) {
             alert('이미 가입한 모임입니다.');
             navigate(`/group/${groupId}`);
           }
         } else if (status === 404) {
           alert('존재하지 않는 글모임입니다.');
-          navigateToLogin();
+          navigate('/');
         } else {
-          alert('올바르지 않은 접근입니다.');
-          navigate('/error');
+          console.error('groupInvite' + status, error.response.data.status);
         }
       }
-    } else {
-      alert('올바르지 않은 접근입니다.');
-      navigate('/error');
     }
   }, [error, isError, groupId]);
 

--- a/src/utils/apis/axios.ts
+++ b/src/utils/apis/axios.ts
@@ -43,10 +43,11 @@ authClient.interceptors.response.use(
         } catch (err) {
           console.error(err);
           localStorage.removeItem('accessToken');
-          // window.location.href = '/';
+          window.location.href = '/login';
         }
       }
       if (err.response.data.status === 40103) {
+        localStorage.setItem('beforePathname', window.location.pathname);
         alert('로그인이 필요한 서비스입니다.');
         window.location.href = '/login';
       }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->


### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 그룹초대페이지 정보 조회 api에서 axios error가 아닌경우 모두 에러페이지로 가게했는데 비동기 처리 순서로 인해 무조건 에러페이지로 가는 현상 수정
- [x] axios interceptor 부분에서 로그인페이지로 이동시키고 로그인 성공시 다시 이전페이지로 돌아가도록 로직 추가
- [x] 그룹 초대페이지 정보 조회 api 500에러 처리

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- document.referrer  속성은 페이지로 이동시키기 이전의 페이지 URI를 반환하는 속성입니다.  해당 페이지로 바로 접근했을시에는 빈 문자열을 반환합니다. 
- window.location 객체는 정말 다양한 속성으로 현재 페이지의 URL을 알아올 수 있는데. 저는 그중에서 pathname을 활용해서 이전페이지로 이동하는 로직을 구현했습니다. 

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
- 

## 📌스크린샷(선택)
