### PR TITLE
[ Hotfix/#441 ] v5 머지 이후 qa (글모임생성 버튼 크기 / 페이지 이탈 모달 겹쳐서 뜨는 이슈 / 메타태그 수정)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="오직 글쓰기 모임을 위한 블로그, 마일에서 모임원들과 함께 글을 쓰며 여러분 만의 공간을 만들어보세요"
     />
-    <!-- <meta property="og:image" content="{mileLinkImg}" /> -->
+    <meta property="og:image" content="https://github.com/user-attachments/assets/52ce1a54-3429-4d0d-9801-e7cda913596f" />
     <meta property="og:url" content="https://www.milewriting.com/" />
     <meta property="og:type" content="website" />
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/svgs/faviconMile.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:title" content="마일 | 글쓰기 모임 | 블로그" />
+    <meta
+      property="og:description"
+      content="오직 글쓰기 모임을 위한 블로그, 마일에서 모임원들과 함께 글을 쓰며 여러분 만의 공간을 만들어보세요"
+    />
+    <!-- <meta property="og:image" content="{mileLinkImg}" /> -->
+    <meta property="og:url" content="https://www.milewriting.com/" />
+    <meta property="og:type" content="website" />
 
     <link
       rel="stylesheet"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import router from './routers/Router';
-// import mileLinkImg from '../src/assets/images/mileLinkImg.png';
 import { RouterProvider } from 'react-router-dom';
 import { Suspense } from 'react';
 import Loading from './pages/loading/Loading';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import router from './routers/Router';
-import mileLinkImg from '../src/assets/images/mileLinkImg.png';
+// import mileLinkImg from '../src/assets/images/mileLinkImg.png';
 import { RouterProvider } from 'react-router-dom';
 import { Suspense } from 'react';
 import Loading from './pages/loading/Loading';
@@ -17,16 +17,6 @@ const App = () => {
   });
   return (
     <>
-      <head>
-        <meta property="og:title" content="마일 | 글쓰기 모임 | 블로그" />
-        <meta
-          property="og:description"
-          content="오직 글쓰기 모임을 위한 블로그, 마일에서 모임원들과 함께 글을 쓰며 여러분 만의 공간을 만들어보세요"
-        />
-        <meta property="og:image" content={mileLinkImg} />
-        <meta property="og:url" content="https://www.milewriting.com/" />
-        <meta property="og:type" content="website" />
-      </head>
       <div style={{ fontSize: '16px' }}>
         <QueryClientProvider client={queryClient}>
           <DesktopWrapper>

--- a/src/pages/admin/components/RenderAdminContent.tsx
+++ b/src/pages/admin/components/RenderAdminContent.tsx
@@ -45,6 +45,11 @@ const RenderAdminContent = ({ admin }: { admin: 'topic' | 'member' | 'groupInfo'
 
   const { mutate: deleteGroup, isPending, isError } = useDeleteGroup(groupId || '');
 
+  const handleDeleteGroup = () => {
+    deleteGroup();
+    setIgnoreBlocker(true);
+  };
+
   if (isError) {
     return <Error />;
   }
@@ -110,7 +115,7 @@ const RenderAdminContent = ({ admin }: { admin: 'topic' | 'member' | 'groupInfo'
           >
             <DefaultModalBtn
               btnText={['예', '아니요']}
-              onClickLeft={deleteGroup}
+              onClickLeft={handleDeleteGroup}
               onClickRight={handleCloseModal}
             />
           </DefaultModal>

--- a/src/pages/createGroup/CreateGroup.tsx
+++ b/src/pages/createGroup/CreateGroup.tsx
@@ -30,7 +30,7 @@ const CreateGroup = () => {
   const [groupImageView, setGroupImageView] = useState('');
 
   // 페이지 이탈 감지
-  const { isPageExitModalOpen, handleClosePageExitModal, handleExitPage } = useBlockPageExit();
+  const { isPageExitModalOpen, handleClosePageExitModal, handleExitPage, setIgnoreBlocker } = useBlockPageExit();
   // modal 열고닫음
   const { isModalOpen, handleShowModal, handleCloseModal } = useModal();
 
@@ -143,6 +143,7 @@ const CreateGroup = () => {
     }
 
     if (groupName && topic && topicTag && leaderPenName && leaderDesc.length <= 100) {
+      setIgnoreBlocker(true);
       mutate();
     } else {
       throw new Error('글모임 생성 알 수 없는 에러');

--- a/src/pages/createGroup/CreateGroup.tsx
+++ b/src/pages/createGroup/CreateGroup.tsx
@@ -253,7 +253,7 @@ const BtnWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  width: 100%;
+  width: 82.6rem;
 `;
 
 const CreateGroupWrapper = styled.div`


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #441 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글모임생성 버튼 크기 
- [x] 페이지 이탈 모달 겹쳐서 뜨는 이슈
- [x] 메타 태그 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 글모임생성 -> 방장 정보 입력할 때 버튼 크기 지정해서 수정해두었습니다.
- 관리자페이지 , 글모임가입페이지에서 모든 정보 입력 후 완료 모달이 뜬 후에, 다음 페이지로 이동할 때 페이지 이탈 모달이 활성화 되는 이슈를 확인했습니다.
- setIgnoerBlocker라고 페이지 이탈 모달을 비활성화 할 수 있는 상태를 이전에 만들어뒀어서 해당 부분 위에 로직들에도 추가해두었습니다.

- 메타태그 관련 작업이 잘 작동하지 않아서 확인해본 결과 App.tsx내부에 있더라구요. index.html 안으로 이동해줬고, 이미지도 github issue활용해서 변환한 url로 넣어두었습니다. 

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
