### PR TITLE
[ Hotfix/#441 ] v5머지 이후 QA - 글모임생성 완료 후 그룹아이디 안 받아와지는 거 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,14 @@
       property="og:description"
       content="오직 글쓰기 모임을 위한 블로그, 마일에서 모임원들과 함께 글을 쓰며 여러분 만의 공간을 만들어보세요"
     />
-    <meta property="og:image" content="https://github.com/user-attachments/assets/52ce1a54-3429-4d0d-9801-e7cda913596f" />
+    <meta
+      property="og:image"
+      content="https://github.com/user-attachments/assets/52ce1a54-3429-4d0d-9801-e7cda913596f"
+    />
     <meta property="og:url" content="https://www.milewriting.com/" />
     <meta property="og:type" content="website" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
 
     <link
       rel="stylesheet"

--- a/src/pages/createGroup/CreateGroup.tsx
+++ b/src/pages/createGroup/CreateGroup.tsx
@@ -30,7 +30,8 @@ const CreateGroup = () => {
   const [groupImageView, setGroupImageView] = useState('');
 
   // 페이지 이탈 감지
-  const { isPageExitModalOpen, handleClosePageExitModal, handleExitPage, setIgnoreBlocker } = useBlockPageExit();
+  const { isPageExitModalOpen, handleClosePageExitModal, handleExitPage, setIgnoreBlocker } =
+    useBlockPageExit();
   // modal 열고닫음
   const { isModalOpen, handleShowModal, handleCloseModal } = useModal();
 
@@ -149,6 +150,7 @@ const CreateGroup = () => {
       throw new Error('글모임 생성 알 수 없는 에러');
     }
   };
+
 
   const handleBackBtn = () => {
     setCurrentPage('GroupInfoPage');

--- a/src/pages/createGroup/apis/postGroup.ts
+++ b/src/pages/createGroup/apis/postGroup.ts
@@ -2,8 +2,11 @@ import { authClient } from '../../../utils/apis/axios';
 
 interface CreateGroupPropTyeps {
   data: {
-    moimId: string;
-    inviteCode: string;
+    accessToken: string;
+    response : {
+      moimId: string;
+      inviteCode: string;
+    }
   };
   status: number;
   message: string;
@@ -20,7 +23,7 @@ export interface CreateGroupRequestTypes {
   topicDesc?: string;
 }
 
-export const postCreateGroup = ({
+export const postCreateGroup = async ({
   groupName,
   groupInfo,
   groupImageFile,
@@ -32,7 +35,7 @@ export const postCreateGroup = ({
   leaderDesc,
 }: CreateGroupRequestTypes) => {
   try {
-    const data = authClient.post<CreateGroupPropTyeps>(`api/moim`, {
+    const data = await authClient.post<CreateGroupPropTyeps>(`api/moim`, {
       moimName: groupName,
       moimDescription: groupInfo,
       isPublic: isPublic,
@@ -43,7 +46,8 @@ export const postCreateGroup = ({
       topicTag: topicTag,
       topicDescription: topicDesc,
     });
-    return data;
+
+    return data.data;
   } catch (err) {
     console.log(err);
     throw err;

--- a/src/pages/createGroup/hooks/queries.ts
+++ b/src/pages/createGroup/hooks/queries.ts
@@ -36,7 +36,7 @@ export const usePostCreateGroup = ({
 }: CreateGroupRequestTypes) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { mutate, data } = useMutation({
+  const { mutate } = useMutation({
     mutationKey: [
       QUERY_KEY_CREATE_GROUP.postCreateGroup,
       {
@@ -65,7 +65,7 @@ export const usePostCreateGroup = ({
       }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY_CREATE_GROUP.postCreateGroup] });
-      navigate(`/group/success/${data.data.data.moimId}`);
+      navigate(`/group/success/${data.data.response.moimId}`);
     },
     onError: (err) => {
       if (isAxiosError(err) && err.response?.status) {
@@ -86,5 +86,5 @@ export const usePostCreateGroup = ({
     },
   });
 
-  return { mutate, data };
+  return { mutate };
 };


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #441 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글모임생성 완료 후 그룹아이디 안 받아와지는 거 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- response로 오는 데이터 타입이 이상하게 지정되어있더라구요 수정했습니다 
- 메타태그의 이미지 크기 지정해줬습니다

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
