### PR TITLE
[ Hotfix/#447 ] 글모임생성 변경된 api 반영 - accessToken 받아오는 로직 반영

### DIFF
--- a/src/pages/createGroup/hooks/queries.ts
+++ b/src/pages/createGroup/hooks/queries.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { getGroupNameValidation } from '../apis/getGroupNameValidation';
 import { CreateGroupRequestTypes, postCreateGroup } from '../apis/postGroup';
 import { isAxiosError } from 'axios';
+import { authClient } from '../../../utils/apis/axios';
 
 export const QUERY_KEY_CREATE_GROUP = {
   getGroupNameValidation: 'getGroupNameValidation',
@@ -65,6 +66,10 @@ export const usePostCreateGroup = ({
       }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY_CREATE_GROUP.postCreateGroup] });
+
+      localStorage.setItem('accessToken', data.data.accessToken);
+      authClient.defaults.headers['Authorization'] = `Bearer ${data.data.accessToken}`;
+
       navigate(`/group/success/${data.data.response.moimId}`);
     },
     onError: (err) => {

--- a/src/pages/groupFeed/GroupFeed.tsx
+++ b/src/pages/groupFeed/GroupFeed.tsx
@@ -28,6 +28,7 @@ import {
 const GroupFeed = () => {
   const { groupId } = useParams();
   const accessToken = localStorage.getItem('accessToken');
+
   const {
     isMember,
     isOwner,

--- a/src/utils/apis/axios.ts
+++ b/src/utils/apis/axios.ts
@@ -13,6 +13,7 @@ export const client = axios.create({
   withCredentials: true,
 });
 const accessToken = localStorage.getItem('accessToken');
+
 export const authClient = axios.create({
   baseURL: `${devBaseUrl}`,
   headers: {
@@ -23,6 +24,19 @@ export const authClient = axios.create({
   },
   withCredentials: true,
 });
+
+// authClient.interceptors.request.use(
+//   (config) => {
+//     const accessToken = localStorage.getItem('accessToken');
+//     if (accessToken) {
+//       config.headers.Authorization = `Bearer ${accessToken}`;
+//     }
+//     return config;
+//   },
+//   (error) => {
+//     return Promise.reject(error);
+//   },
+// );
 
 authClient.interceptors.response.use(
   (config) => {


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #447 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글모임생성 변경된 api 반영 - accessToken 받아오는 로직 반영

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 글모임 생성할 때 서버에서 응답으로 넘겨주는 데이터가 바뀐 것 같더라구요 ! 회의할 때 accessToken을 새로 발급해준다고 들었던 것 같아서 찾아보니 api가 변경 완료 되어있길래 반영했습니다.

- `usePostCreateGroup` api에서 onSuccess일 경우 localStorage의 accessToken을 변경해주고, authClient의 헤더도 최신화 시켜주도록 반영해두었습니다.

- 처음에는 localStorage.setItem을 해서 업데이트만 시켜줬는데, 이렇게하니까 글모임페이지에 들어갔을 때 필명과 소개글 정보가 받아와지지 않고 403 에러가 나더라구요. 새로고침을 하면 잘 받아와지는 것을 확인했습니다.
- 보니까 `usePostCreateGroup`의 응답값으로 새로운 토큰이 잘 넘어오긴 하지만, authClient의 헤더에 들어가있는 토큰 최신화 작업이 즉시 반영되지 않아서 이전 토큰으로 요청이 가는거더라구요
- 따라서 `onSuccess` 로직에 authClient 헤더 최신화 작업도 추가해주었습니다.

```typescript
// createGroup > queries.ts > usePostCreateGroup

  onSuccess: (data) => {
    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_CREATE_GROUP.postCreateGroup] });

    localStorage.setItem('accessToken', data.data.accessToken);
    // authClient 헤더 최신화
    authClient.defaults.headers['Authorization'] = `Bearer ${data.data.accessToken}`;

    navigate(`/group/success/${data.data.response.moimId}`);
  },

```

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
- 헤더 최신화 작업을 어디서 실행할지에 대해 결정을 못내렸는데 의견 부탁드려요
- 토큰을 최신화하는 작업이 현재는 글모임생성했을 경우, 글모임에 가입했을 경우 이렇게 두 가지인 걸로 확인이되는데 우선은 글모임 생성했을 경우에 대한 작업만 진행해두었습니다.
- 고민인 부분은 이렇게 토큰을 최신화하여 authClient의 헤더를 최신화하는 작업을 axios 내부에서 interceptor를 사용해서 매번 실행해주는게 좋을지
```typescript
// axios.ts
authClient.interceptors.request.use(
  (config) => {
    const accessToken = localStorage.getItem('accessToken');
    if (accessToken) {
      config.headers.Authorization = `Bearer ${accessToken}`;
    }
    return config;
  },
  (error) => {
    return Promise.reject(error);
  },
);
```
- 아니면 현재 작업해둔 것 처럼 새로운 토큰을 응답값으로 받아올 때 직접적으로 헤더를 갈아끼워주는게 좋을지 고민입니다.
```typescript
  onSuccess: (data) => {
    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_CREATE_GROUP.postCreateGroup] });

    localStorage.setItem('accessToken', data.data.accessToken);
    authClient.defaults.headers['Authorization'] = `Bearer ${data.data.accessToken}`;

    navigate(`/group/success/${data.data.response.moimId}`);
  },
```

- 우선은 하나 내지 두개의 api에서만 이런 부분이 필요해서 수동적으로 넣어주는게 좋겠다 판단한 후 현재와 같이 작업 진행해두었는데, 아예 한 번에 관리하는게 나을지요 ... 

## 📌스크린샷(선택)
