### PR TITLE
[ Hotfix/#449 ] 글 모임 초대 페이지 변경된 api 반영

### DIFF
--- a/src/pages/groupInvite/apis/createGroupMemberJoin.ts
+++ b/src/pages/groupInvite/apis/createGroupMemberJoin.ts
@@ -9,6 +9,9 @@ interface groupMemberJoinType {
 interface PostGroupJoinMemberResponseType {
   status: number;
   message: string;
+  data: {
+    accessToken: string;
+  };
 }
 
 export const createGroupMemberJoin = async ({
@@ -17,7 +20,7 @@ export const createGroupMemberJoin = async ({
   writerDescription,
 }: groupMemberJoinType) => {
   try {
-    const { data } = await authClient.post<PostGroupJoinMemberResponseType>(
+    const data = await authClient.post<PostGroupJoinMemberResponseType>(
       `/api/moim/${groupId}/user`,
       {
         moimId: groupId,
@@ -25,7 +28,7 @@ export const createGroupMemberJoin = async ({
         writerDescription: writerDescription,
       },
     );
-    return data;
+    return data.data;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/pages/groupInvite/hooks/queries.ts
+++ b/src/pages/groupInvite/hooks/queries.ts
@@ -5,6 +5,7 @@ import { createGroupMemberJoin } from '../apis/createGroupMemberJoin';
 import { fetchGroupInfo } from '../apis/fetchGroupInfo';
 import { fetchWriterNameConflict } from '../apis/fetchWriterNameConflict';
 import { isAxiosError } from 'axios';
+import { authClient } from '../../../utils/apis/axios';
 
 export const QUERY_KEY_GROUP_INVITE = {
   getGroupInfo: 'getGroupInfo',
@@ -70,7 +71,10 @@ export const usePostGroupMemberJoin = ({
     ],
     mutationFn: () => createGroupMemberJoin({ groupId, writerName, writerDescription }),
     retry: 1,
-    onSuccess: () => {
+    onSuccess: (data) => {
+      localStorage.setItem('accessToken', data.data.accessToken);
+      authClient.defaults.headers['Authorization'] = `Bearer ${data.data.accessToken}`;
+
       navigate(`/group/${groupId}/groupJoin`, {
         state: {
           moimTitle: moimTitle,

--- a/src/pages/groupJoinCongrats/GroupJoinCongrats.tsx
+++ b/src/pages/groupJoinCongrats/GroupJoinCongrats.tsx
@@ -18,7 +18,7 @@ const GroupJoinCongrats = () => {
   return (
     <GroupJoinCongratsWrapper>
       <DefaultHeader />
-      <Spacing marginBottom="11.4" />
+      <Spacing marginBottom="15.6" />
       <GroupJoinCongratsContainer>
         <GroupJoinTitleWrapper>
           <GroupJoinTitle>{location?.state?.moimTitle} 가입을 축하해요!</GroupJoinTitle>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #449 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글 모임 초대 페이지 변경된 api 반영 - accessToken 업데이트

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 이전 피알과 같이, 글모임에 가입했을 때 토큰을 새로 발급해주도록 api가 변경되어있어서 반영했습니다

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
