### PR TITLE
[ Fix: 오늘의 글감/카테고리 api 삭제, 글감리스트 api활용 ]

### DIFF
--- a/src/pages/groupFeed/GroupFeed.tsx
+++ b/src/pages/groupFeed/GroupFeed.tsx
@@ -22,6 +22,7 @@ import {
   useGroupFeedAuth,
   useGroupFeedPublicStatus,
   useGroupInfo,
+  useTopicList,
 } from './hooks/queries';
 
 const GroupFeed = () => {
@@ -49,6 +50,12 @@ const GroupFeed = () => {
 
   const { groupInfoData } = useGroupInfo(groupId || '');
   const { writerName, writerNameId } = useFetchWriterNameOnly(groupId || '', isMember, isOwner);
+  const {
+    groupFeedCategoryData,
+    isLoading: topicListLoading,
+    isError: topicListisError,
+    error: topicListError,
+  } = useTopicList(groupId || '');
 
   const navigate = useNavigate();
 
@@ -94,7 +101,12 @@ const GroupFeed = () => {
           />
         )}
         <GroupInfo>
-          <GroupTodayWriteStyle isMember={isMember} groupId={groupId} />
+          <GroupTodayWriteStyle
+            isMember={isMember}
+            groupId={groupId}
+            groupFeedTopic={groupFeedCategoryData && groupFeedCategoryData[0].topicName}
+            groupFeedCategory={groupFeedCategoryData && groupFeedCategoryData[0].content}
+          />
           <Spacing marginBottom="6.4" />
           <GroupCuriousTitle
             mainText="우리 모임에서 궁금한 글쓴이에요"
@@ -110,7 +122,12 @@ const GroupFeed = () => {
           <Spacing marginBottom="2" />
           <CuriousArticle groupId={groupId} />
           <Spacing marginBottom="6.4" />
-          <Carousel />
+          <Carousel
+            groupFeedCategoryData={groupFeedCategoryData}
+            isError={topicListisError}
+            error={topicListError}
+            isLoading={topicListLoading}
+          />
         </GroupInfo>
       </GroupInfoWrapper>
       <Spacing marginBottom="14" />

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -108,6 +108,7 @@ interface TopicListPropTypes {
     topicList: {
       topicId: string;
       topicName: string;
+      content: string;
     }[];
   };
   status: number;

--- a/src/pages/groupFeed/apis/fetchGroupFeed.ts
+++ b/src/pages/groupFeed/apis/fetchGroupFeed.ts
@@ -63,24 +63,6 @@ export const fetchGroupPublicStatus = async (groupId: string) => {
     console.error('에러:', error);
   }
 };
-
-interface TodayTopicPropTypes {
-  data: {
-    content: string;
-  };
-  status: number;
-  message: string;
-}
-
-export const fetchTodayTopic = async (groupId: string) => {
-  try {
-    const response = await client.get<TodayTopicPropTypes>(`/api/moim/${groupId}/topic/today`);
-    return response.data;
-  } catch (error) {
-    console.error('에러:', error);
-  }
-};
-
 interface CuriousWriterPropTypes {
   data: {
     popularWriters: {

--- a/src/pages/groupFeed/carousel/Carousel.tsx
+++ b/src/pages/groupFeed/carousel/Carousel.tsx
@@ -8,16 +8,28 @@ import EachArticle from './EachArticle';
 import './slick-theme.css';
 import './slick.css';
 
-import { useArticleList, useTopicList } from '../hooks/queries';
+import { useArticleList } from '../hooks/queries';
 
 // import { GroupTabBtnBaseBeforeIc, GroupTabBtnBaseNextIc } from '../../../assets/svgs';
 import Spacing from '../../../components/commons/Spacing';
 import Error from '../../error/Error';
 import Loading from '../../loading/Loading';
 
-const Carousel = () => {
+type Topic = {
+  topicId: string;
+  topicName: string;
+};
+
+type GroupFeedCategoryData = Topic[];
+
+type CarouselPropsType<TError = Error> = {
+  groupFeedCategoryData: GroupFeedCategoryData | undefined;
+  isError: boolean;
+  isLoading: boolean;
+  error: TError | null;
+};
+const Carousel = ({ groupFeedCategoryData, isError, isLoading, error }: CarouselPropsType) => {
   const { groupId } = useParams();
-  const { groupFeedCategoryData, isLoading, isError, error } = useTopicList(groupId || '');
 
   const [selectedTopicId, setSelectedTopicId] = useState<string>('');
 

--- a/src/pages/groupFeed/components/GroupTodayWriteStyle.tsx
+++ b/src/pages/groupFeed/components/GroupTodayWriteStyle.tsx
@@ -2,36 +2,27 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '../../../components/commons/Button';
-import Error from '../../error/Error';
-import Loading from '../../loading/Loading';
-import { useTodayTopic } from '../hooks/queries';
 interface GroupTodayWriteStylePropTypes {
   isMember: boolean | undefined; //나의 글 작성하기 권한 확인
   groupId: string | undefined; //오늘의 주제
+  groupFeedTopic: string | undefined;
+  groupFeedCategory: string | undefined;
 }
 
 const GroupTodayWriteStyle = (props: GroupTodayWriteStylePropTypes) => {
   const navigate = useNavigate();
-  const { isMember, groupId } = props;
-  const { content, isLoading, isError, error } = useTodayTopic(groupId || '');
+  const { isMember, groupId, groupFeedTopic, groupFeedCategory } = props;
 
   const handleNavigatePostPage = () => {
     navigate(`/post/${groupId}/post`);
   };
-  if (isLoading) {
-    return <Loading />;
-  }
 
-  if (isError) {
-    console.log(error?.message, 'error');
-    return <Error />;
-  }
   return (
     <TodayWriteStyleWrapper>
       <TextLayout>
-        <MainText>글감 카테고리 자리</MainText>
+        <MainText>{groupFeedTopic}</MainText>
         <SubText>
-          오늘의 주제는 <SubBoldText>{content}</SubBoldText> 입니다.
+          오늘의 주제는 <SubBoldText>{groupFeedCategory}</SubBoldText> 입니다.
         </SubText>
       </TextLayout>
       {isMember && (

--- a/src/pages/groupFeed/hooks/queries.ts
+++ b/src/pages/groupFeed/hooks/queries.ts
@@ -8,7 +8,6 @@ import {
   fetchGroupFeedAuth,
   fetchGroupInfo,
   fetchGroupPublicStatus,
-  fetchTodayTopic,
   fetchTopicList,
   fetchWriterInfo,
   fetchWriterNameOnly,
@@ -89,16 +88,6 @@ export const useGroupInfo = (groupId: string): GroupInfoQueryResult => {
   const groupInfoData = data?.data;
 
   return { groupInfoData, isLoading, isError, error };
-};
-
-export const useTodayTopic = (groupId: string) => {
-  const { data, isLoading, isError, error } = useQuery({
-    queryKey: groupKey.topic(groupId),
-    queryFn: () => fetchTodayTopic(groupId),
-  });
-
-  const content = data && data.data.content;
-  return { content, isLoading, isError, error };
 };
 
 export const useCuriousPost = (groupId: string) => {


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
#453 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [ ] 오늘의 글감/ 카테고리 api 삭제한 후 글감 리스트 api를 활용하여 오늘의 글감 렌더링

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/ad0dfe74-ecf7-4871-a721-a865de910190">

