### PR TITLE
[design/#463] 글감태그 정렬 수정

### DIFF
--- a/src/pages/admin/components/EachTopic.tsx
+++ b/src/pages/admin/components/EachTopic.tsx
@@ -120,7 +120,7 @@ const TopicWrapper = styled.div`
 const TopicData = styled.div`
   display: flex;
   gap: 4rem;
-  align-items: center;
+  align-items: flex-start;
   width: 64.9rem;
   height: 5.2rem;
 `;
@@ -145,6 +145,7 @@ const TopicDate = styled.p`
 
 const TopicTag = styled.p`
   width: 7rem;
+  padding: 0.6rem 0;
 
   color: ${({ theme }) => theme.colors.black};
   ${({ theme }) => theme.fonts.body1};

--- a/src/pages/admin/components/EachTopic.tsx
+++ b/src/pages/admin/components/EachTopic.tsx
@@ -155,6 +155,7 @@ const TopicTag = styled.p`
 const TopicDescription = styled.p`
   display: -webkit-box;
   width: 29rem;
+  padding-top: 0.2rem;
   overflow: hidden;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #463 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글감태그 정렬 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 글감 설명이 두 줄일 경우 글감 태그가 글감 높이에 맞도록 정렬되게 수정했어요

## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
[이전]
<img width="894" alt="image" src="https://github.com/user-attachments/assets/bca8ad64-4951-4083-a468-12e36c7a3229">


[이후]
- 글감 소개 한 줄
<img width="860" alt="image" src="https://github.com/user-attachments/assets/7ad790e8-3ffc-4867-8bf4-8963a63f2455">


-글감 소개 두 줄
<img width="858" alt="image" src="https://github.com/user-attachments/assets/fd79f1f1-674e-44d0-a34d-c095266a7232">

