### PR TITLE
[design/#465] 글상세페이지 숫자, 영문, 특수문자 줄바꿈 안됨 이슈

### DIFF
--- a/src/pages/groupFeed/carousel/Carousel.tsx
+++ b/src/pages/groupFeed/carousel/Carousel.tsx
@@ -114,6 +114,5 @@ const TopicDescription = styled.div`
   width: 63.1rem;
 
   color: ${({ theme }) => theme.colors.gray70};
-
   ${({ theme }) => theme.fonts.body3};
 `;

--- a/src/pages/groupFeed/carousel/EachArticle.tsx
+++ b/src/pages/groupFeed/carousel/EachArticle.tsx
@@ -187,8 +187,8 @@ const ArticleContent = styled.div`
   overflow: hidden;
 
   color: ${({ theme }) => theme.colors.gray70};
-
   ${({ theme }) => theme.fonts.body3};
+  word-break: break-all;
 `;
 
 const ArticleInfo = styled.div`

--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -254,6 +254,7 @@ const DetailBox = styled.div`
 const TitleText = styled.h1`
   color: ${({ theme }) => theme.colors.grayBlack};
   ${({ theme }) => theme.fonts.title1};
+  word-break: break-all;
 `;
 
 const DateText = styled.p`

--- a/src/pages/postDetail/PostDetail.tsx
+++ b/src/pages/postDetail/PostDetail.tsx
@@ -326,7 +326,7 @@ const PostContainer = styled.div`
   min-height: 6rem;
   padding: 3.6rem;
 
-  word-break: keep-all;
+  word-break: break-all;
 
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 10px;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #465 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 글 상세페이지 숫자, 영문, 특수문자 줄바꿈 안됨 이슈

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- word-break: keep-all 
영문, 숫자, 특수문자 띄어쓰기 없이 썼을 경우 줄바꿈 안됨, 한글 강제 줄바꿈 됨

- word-break: break-all
영문, 숫자, 특수문자 띄어쓰기 없이 썼을 경우 줄바꿈 됨. 영문 단어 단위로 줄바꿈됨. 한글 강제 줄바꿈 됨.


## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)
[이전]
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/415b3dda-068b-4a7c-b166-401c1d8e89a7">

[이후]
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4e284171-e935-4d2a-af5a-761fc7a7b0ba">

