### PR TITLE
[fix/#550] 메인페이지 글모임 글 리스트 반응형 캐러셀 적용

### DIFF
--- a/src/pages/main/components/CarouselContent.tsx
+++ b/src/pages/main/components/CarouselContent.tsx
@@ -82,15 +82,17 @@ const CarouselWrapper = styled.section`
   display: flex;
   gap: 5rem;
   width: 93rem;
+
   cursor: pointer;
 `;
 
 const CarouselContentLayout = styled.div`
   display: flex;
   gap: 3.6rem;
+  width: 100%;
   height: 24rem;
   padding: 3.6rem;
-  width: 100%;
+
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
 

--- a/src/pages/main/components/GroupCarousel.tsx
+++ b/src/pages/main/components/GroupCarousel.tsx
@@ -160,7 +160,6 @@ const NoImageContents = styled.span`
 const Contents = styled.span`
   display: -webkit-box;
   width: 100%;
-
   margin-top: 1rem;
   overflow: hidden;
 
@@ -204,10 +203,11 @@ const PostCard = styled.article`
 const CarouselWrapper = styled.div`
   flex-direction: column;
   height: 29.4rem;
+
   cursor: default;
+
   @media ${MOBILE_MEDIA_QUERY} {
     height: 34.4rem;
-    padding: 0 2rem;
   }
 `;
 
@@ -234,6 +234,10 @@ const GroupButton = styled.button`
       stroke: #6139d1;
     }
   }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-left: 2rem;
+  }
 `;
 
 const CarouselLayout = styled.div`
@@ -245,6 +249,11 @@ const CarouselLayout = styled.div`
   ::-webkit-scrollbar {
     display: none;
   }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 0 2rem;
+    overflow: scroll;
+  }
 `;
 
 const CarouselContainer = styled(Slider)`
@@ -254,13 +263,12 @@ const CarouselContainer = styled(Slider)`
   .slick-list {
     width: 100%;
   }
+
   .slick-slide.slick-active:last-child {
     width: 75.4rem !important;
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
-    /* width: 45rem; */
-
     display: flex;
     gap: 2rem;
     width: 100%;
@@ -277,7 +285,6 @@ const PostContainer = styled.div`
   display: flex;
   gap: 2rem;
   width: 100%;
-
   height: 29rem;
   overflow: hidden;
 `;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- 또는 이슈닫는 방법 closes #{이슈번호}-->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #550 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 메인페이지 글모임 글리스트 모바일일 경우 가로 스크롤 생기는 이슈 수정

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
- 메인페이지 글모임 글리스트 모바일일 경우 가로 스크롤 생기는 이슈 수정
- 기존에 데스크탑일 경우 사용하고 있는 캐러셀 컴포넌트를 사용하려다가 모바일일 경우 overflow : scroll 적용하는 방향으로 수정했어요. 
- 나중에 제대로 적용하려면 [slick-slider에 전달하는 setting에 responsive 속성 추가해서 수정해봐도 괜찮을듯합니다.](https://react-slick.neostack.com/docs/example/responsive)


## 📌 질문할 부분 
<!-- 질문은 팀에게 도움이 됩니다  -->
-

## 📌스크린샷(선택)

https://github.com/user-attachments/assets/599d219d-0387-4e4f-9ff9-5a05e06c5f9c

